### PR TITLE
私信分享视频显示为可点视频卡片(修媒体消息空气泡)

### DIFF
--- a/app/browser/account_hub.py
+++ b/app/browser/account_hub.py
@@ -1199,6 +1199,11 @@ async def fetch_dm_history(mgr: BrowserManager, identity, platform: str,
                   f"resp_len={len(body)} msgs={len(parsed.get('messages', []))} "
                   f"next_cursor={parsed.get('next_cursor')}")
             print(f"[dm-hist-raw] b64:{_b64.b64encode(body[:1200]).decode()}")
+            # 非文本消息(分享视频=8/图片=27/语音=17...)dump 原始 content JSON,标定字段用
+            for _m in parsed.get("messages", []):
+                if _m.get("msg_type") not in (7, 0):
+                    print(f"[dm-hist-content] type={_m.get('msg_type')} "
+                          f"text={_m.get('text')!r} content={_m.get('content')}")
         if resp.status != 200:
             return parsed, f"imapi 返回 {resp.status}"
         return parsed, ""

--- a/app/browser/douyin_im_pb.py
+++ b/app/browser/douyin_im_pb.py
@@ -79,19 +79,73 @@ def _s(v) -> str:
 _AWE_LABEL = {507: "[表情]", 5: "[表情]", 11048: "[小程序卡片]",
               100157: "[系统通知]", 2702: "[小程序]"}
 
+# 消息类型(MessageBody.field6)→ 占位。实测标定见 DouYin_Spider/douyin_recv_msg.py:
+#   7=文本 5=表情 17=语音 27=图片 8=分享视频。媒体类消息 content 里没有 .text,
+#   只认 .text 会让分享视频/图片/语音等显示成空气泡,故按 msg_type 兜底给占位。
+_MSG_TYPE_LABEL = {5: "[表情]", 8: "[视频]", 17: "[语音]", 27: "[图片]"}
 
-def _preview_text(content: bytes) -> str:
-    """从消息 content(JSON 串)取会话列表预览文本。"""
+
+def _share_video_text(obj: dict) -> str:
+    """分享视频卡片(msg_type=8)预览。实测 content 字段(标定见 fetch_dm_history debug):
+      content_title=视频标题(偶尔空,如图集/直播分享) content_name=作者昵称
+      cover_url.url_list=封面 itemId=视频ID secUID=作者。
+    标题优先;标题空退回 @作者;都没有才纯 [视频],绝不返回空。"""
+    title = obj.get("content_title")
+    if isinstance(title, str) and title.strip():
+        return "[视频] " + title.strip()
+    author = obj.get("content_name")
+    if isinstance(author, str) and author.strip():
+        return "[视频] @" + author.strip()
+    return "[视频]"
+
+
+def _first_url(d) -> str:
+    u = d.get("url_list") if isinstance(d, dict) else None
+    return u[0] if isinstance(u, list) and u and isinstance(u[0], str) else ""
+
+
+def share_video_card(content) -> Optional[dict]:
+    """分享视频(msg_type=8)→ 前端卡片渲染字段。content 可为 JSON 串/bytes/dict。
+    抽 {kind, item_id, title, author, author_sec_uid, cover, avatar};非视频卡返回 None。"""
+    if isinstance(content, (bytes, bytearray)):
+        try:
+            content = json.loads(bytes(content).decode("utf-8"))
+        except Exception:
+            return None
+    elif isinstance(content, str):
+        try:
+            content = json.loads(content)
+        except Exception:
+            return None
+    if not isinstance(content, dict) or not content.get("itemId"):
+        return None
+    return {
+        "kind": "video",
+        "item_id": str(content.get("itemId") or ""),
+        "title": str(content.get("content_title") or ""),
+        "author": str(content.get("content_name") or ""),
+        "author_sec_uid": str(content.get("secUID") or ""),
+        "cover": _first_url(content.get("cover_url")),
+        "avatar": _first_url(content.get("content_thumb")),
+    }
+
+
+def _preview_text(content: bytes, msg_type=None) -> str:
+    """从消息 content(JSON 串)取会话列表/气泡预览文本。
+    msg_type(可选)= MessageBody.field6,用于给媒体类消息(分享视频/图片/语音/表情)
+    兜底占位——这些消息 content 无 .text,不给占位就会显示成空白。"""
     if not isinstance(content, bytes) or not content:
-        return ""
+        return _MSG_TYPE_LABEL.get(msg_type, "")
     try:
         obj = json.loads(content.decode("utf-8"))
     except Exception:
-        return ""
+        return _MSG_TYPE_LABEL.get(msg_type, "")
     if not isinstance(obj, dict):
-        return ""
+        return _MSG_TYPE_LABEL.get(msg_type, "")
     if obj.get("text"):
         return str(obj["text"])
+    if msg_type == 8 or obj.get("itemId"):     # 分享视频
+        return _share_video_text(obj)
     if obj.get("trans_type") is not None:      # 转账
         return "[转账] " + str(obj.get("title") or "")
     lbl = _AWE_LABEL.get(obj.get("aweType"))
@@ -101,7 +155,7 @@ def _preview_text(content: bytes) -> str:
         return str(obj["push_detail"])
     if obj.get("description"):
         return str(obj["description"])
-    return ""
+    return _MSG_TYPE_LABEL.get(msg_type, "")   # 按类型兜底,别返回空
 
 
 def peer_uid_from_conv_id(conv_id: str, self_uid: str) -> str:
@@ -171,7 +225,8 @@ def parse_conversations(raw: bytes) -> List[dict]:
             "peer_uid": peer_uid,
             "peer_sec_uid": peer_sec,
             "ticket": _s(_first(core, 4, b"")),
-            "last_text": _preview_text(content if isinstance(content, bytes) else b""),
+            "last_text": _preview_text(
+                content if isinstance(content, bytes) else b"", _first(msg, 6)),
             "last_msg_type": _first(msg, 6),
             "last_sender_uid": _s(_first(msg, 7)),
             "last_time": _msg_create_ts(msg),
@@ -349,14 +404,16 @@ def _msg_from_body(mb: bytes) -> Optional[dict]:
         return None
     content = _first(m, 8, b"")
     content = content if isinstance(content, bytes) else b""
+    msg_type = _first(m, 6) or 0
     return {
         "conv_id": conv_id,
         "server_msg_id": _s(_first(m, 3)),
         "index": _first(m, 4) or 0,
-        "msg_type": _first(m, 6) or 0,
+        "msg_type": msg_type,
         "sender_uid": _s(_first(m, 7)),
         "content": content.decode("utf-8", "ignore"),
-        "text": _preview_text(content),
+        "text": _preview_text(content, msg_type),
+        "card": share_video_card(content) if msg_type == 8 else None,
         "create_time": _msg_create_ts(m),
         "sender_sec_uid": _s(_first(m, 14, b"")),
     }

--- a/app/browser/douyin_im_ws.py
+++ b/app/browser/douyin_im_ws.py
@@ -12,7 +12,8 @@ import hashlib
 from typing import Callable, Dict, List, Optional
 
 from .douyin_im_pb import (_get_fields, _first, _s, _preview_text,
-                           _msg_create_ts, peer_uid_from_conv_id)
+                           _msg_create_ts, peer_uid_from_conv_id,
+                           share_video_card)
 
 _APP_KEY = "e1bd35ec9db7b8d846de66ed140b1ad9"
 _FPID = "9"
@@ -68,13 +69,15 @@ def decode_push_frame(raw: bytes, self_uid: str = "") -> List[dict]:
     content = _first(m, 8, b"")
     content = content if isinstance(content, bytes) else b""
     sender = _s(_first(m, 7))
+    msg_type = _first(m, 6) or 0
     return [{
         "conv_id": conv_id,
         "conv_short_id": _s(_first(m, 5)),
         "server_msg_id": _s(_first(m, 3)),
-        "msg_type": _first(m, 6) or 0,
+        "msg_type": msg_type,
         "sender_uid": sender,
-        "text": _preview_text(content),
+        "text": _preview_text(content, msg_type),
+        "card": share_video_card(content) if msg_type == 8 else None,
         "create_time": _msg_create_ts(m),
         "peer_uid": peer_uid_from_conv_id(conv_id, self_uid),
         "is_self": bool(self_uid) and sender == self_uid,

--- a/app/engine/im_receiver.py
+++ b/app/engine/im_receiver.py
@@ -110,11 +110,13 @@ class ImReceiverManager:
                     DmMessage.msg_id == "last:" + conv_id)).first()
                 if ph:
                     s.delete(ph)
+                card = m.get("card")
                 s.add(DmMessage(
                     platform="douyin", account_id=account_id, conv_id=conv_id,
                     msg_id=mid or f"ws:{ts}:{m.get('sender_uid')}",
-                    direction=direction, msg_type="text",
-                    text=m.get("text") or "", create_time=ts))
+                    direction=direction, msg_type=("video" if card else "text"),
+                    text=m.get("text") or "", create_time=ts,
+                    raw_json=json.dumps(card, ensure_ascii=False) if card else ""))
                 conv = s.exec(select(DmConversation).where(
                     DmConversation.account_id == account_id,
                     DmConversation.conv_id == conv_id)).first()
@@ -131,7 +133,7 @@ class ImReceiverManager:
         st = self._accts.get(account_id)
         if st:
             evt = {"conv_id": conv_id, "text": m.get("text"),
-                   "direction": direction, "create_time": ts,
+                   "direction": direction, "create_time": ts, "card": m.get("card"),
                    "sender_uid": m.get("sender_uid"), "peer_uid": m.get("peer_uid")}
             for q in list(st["queues"]):
                 try:

--- a/app/main.py
+++ b/app/main.py
@@ -719,8 +719,17 @@ async def list_dm_messages(account_id: int, conv_id: str, limit: int = 200):
         q = (select(DmMessage).where(DmMessage.account_id == account_id,
                                      DmMessage.conv_id == conv_id)
              .order_by(DmMessage.create_time.asc()).limit(limit))
+
+        def _card(m):
+            if not m.raw_json:
+                return None
+            try:
+                return json.loads(m.raw_json)
+            except Exception:
+                return None
         return [{"id": m.id, "direction": m.direction, "text": m.text,
-                 "msg_type": m.msg_type, "create_time": m.create_time}
+                 "msg_type": m.msg_type, "create_time": m.create_time,
+                 "card": _card(m)}
                 for m in s.exec(q).all()]
 
 
@@ -877,15 +886,24 @@ async def fetch_dm_conversation_history(account_id: int, conv_id: str,
             seen.add(mid)
             direction = ("out" if self_uid and m.get("sender_uid") == self_uid
                          else "in")
+            card = m.get("card")
             s.add(DmMessage(
                 platform=platform, account_id=account_id, conv_id=conv_id,
                 msg_id=mid, direction=direction,
-                msg_type=("text" if m.get("text") else str(m.get("msg_type") or "")),
-                text=m.get("text") or "", create_time=int(m.get("create_time") or 0)))
+                msg_type=("video" if card else
+                          "text" if m.get("text") else str(m.get("msg_type") or "")),
+                text=m.get("text") or "", create_time=int(m.get("create_time") or 0),
+                raw_json=json.dumps(card, ensure_ascii=False) if card else ""))
             added += 1
         s.commit()
-    return {"ok": True, "fetched": len(msgs), "added": added,
-            "next_cursor": parsed.get("next_cursor"), "has_more": parsed.get("has_more")}
+    out = {"ok": True, "fetched": len(msgs), "added": added,
+           "next_cursor": parsed.get("next_cursor"), "has_more": parsed.get("has_more")}
+    if debug:   # 非文本消息(分享视频=8/图片=27/语音=17...)回原始 content,标定字段用
+        out["media_samples"] = [
+            {"msg_type": m.get("msg_type"), "text": m.get("text"),
+             "content": m.get("content")}
+            for m in msgs if m.get("msg_type") not in (7, 0)]
+    return out
 
 
 # ─────────── 本账号管理:计数汇总(账号管理面板徽章,纯查库不触发抓取)───────────
@@ -2853,7 +2871,17 @@ async def test_channel(cid: int):
 # ─────────── 前端 ───────────
 @app.get("/", response_class=HTMLResponse)
 async def index():
-    return (WEB_DIR / "index.html").read_text(encoding="utf-8")
+    html = (WEB_DIR / "index.html").read_text(encoding="utf-8")
+    # 给 app.js 带上基于 mtime 的版本号,前端改动后自动击穿浏览器缓存(免手动强刷)
+    try:
+        ver = int((WEB_DIR / "app.js").stat().st_mtime)
+        html = html.replace("/static/app.js", f"/static/app.js?v={ver}")
+    except Exception:
+        pass
+    # 首页(含内联 CSS)禁缓存:否则 webview 缓存旧 HTML,改了样式也不生效
+    return HTMLResponse(html, headers={
+        "Cache-Control": "no-cache, no-store, must-revalidate",
+        "Pragma": "no-cache", "Expires": "0"})
 
 
 app.mount("/static", StaticFiles(directory=str(WEB_DIR)), name="static")

--- a/app/web/app.js
+++ b/app/web/app.js
@@ -1027,12 +1027,33 @@ function markDmRead(convId) {
   api(`/api/accounts/${HUB_ACC}/dm/conversations/${convId}/mark-read`, { method: "POST" })
     .then(() => refreshDmConvs()).catch(() => {});
 }
+// 分享视频卡片(msg_type=8):封面+标题+作者,点击跳抖音该视频
+function dmVideoCard(c) {
+  const url = c.item_id ? `https://www.douyin.com/video/${encodeURIComponent(c.item_id)}` : "#";
+  const cover = c.cover
+    ? `<img src="${esc(c.cover)}" loading="lazy" referrerpolicy="no-referrer" onerror="this.style.display='none'">`
+    : "";
+  const avatar = c.avatar
+    ? `<img class="av" src="${esc(c.avatar)}" loading="lazy" referrerpolicy="no-referrer" onerror="this.style.display='none'">`
+    : "";
+  return `<a class="dm-vcard" href="${url}" target="_blank" rel="noopener">
+    <div class="cov">${cover}<span class="play">▶</span></div>
+    <div class="meta">
+      <div class="ttl">${esc(c.title || "[视频]")}</div>
+      <div class="au">${avatar}<span>${esc(c.author || "")}</span></div>
+    </div>
+  </a>`;
+}
+function dmBody(m) {
+  if (m.card && m.card.kind === "video") return dmVideoCard(m.card);
+  return esc(m.text);
+}
 async function refreshDmMessages() {
   const thread = $("dm-thread"); if (!thread || !HUB_ACC || !DM_CONV) return;
   try {
     const msgs = await api(`/api/dm/messages?account_id=${HUB_ACC}&conv_id=${encodeURIComponent(DM_CONV)}`);
     thread.innerHTML = msgs.length
-      ? msgs.map(m => `<div class="dm-bubble ${m.direction === "out" ? "out" : "in"}">${esc(m.text)}<span class="t">${fmtTime(m.create_time)}</span></div>`).join("")
+      ? msgs.map(m => `<div class="dm-bubble ${m.direction === "out" ? "out" : "in"}${m.card ? " card" : ""}">${dmBody(m)}<span class="t">${fmtTime(m.create_time)}</span></div>`).join("")
       : `<div class="empty"><div class="empty-t">暂无消息记录</div><div class="empty-sub">该会话没有可拉取的历史(或对方为系统号)</div></div>`;
     thread.scrollTop = thread.scrollHeight;
   } catch (e) { thread.innerHTML = `<div class="empty"><div class="empty-t">加载失败:${esc(e.message)}</div></div>`; }

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -346,10 +346,24 @@
   .dm-conv .unread { background:var(--acc); color:#fff; font:600 10px/1 var(--mono); padding:2px 6px; border-radius:999px; flex:0 0 auto; }
   .dm-main { display:flex; flex-direction:column; min-width:0; }
   .dm-thread { flex:1; padding:16px; overflow-y:auto; max-height:500px; display:flex; flex-direction:column; gap:8px; }
-  .dm-bubble { max-width:72%; padding:8px 12px; border-radius:12px; font-size:13px; line-height:1.5; word-break:break-word; white-space:pre-wrap; }
+  .dm-bubble { max-width:72%; flex:0 0 auto; padding:8px 12px; border-radius:12px; font-size:13px; line-height:1.5; word-break:break-word; white-space:pre-wrap; }
   .dm-bubble.in { align-self:flex-start; background:var(--surface-3); color:var(--fg); border-bottom-left-radius:3px; }
   .dm-bubble.out { align-self:flex-end; background:var(--acc); color:#fff; border-bottom-right-radius:3px; }
   .dm-bubble .t { display:block; font-size:10px; opacity:.7; margin-top:3px; }
+  /* 分享视频卡片 */
+  .dm-bubble.card { padding:0; overflow:hidden; background:var(--surface-3); max-width:60%; }
+  .dm-bubble.out.card { background:var(--surface-3); }
+  .dm-bubble.card .t { padding:0 10px 6px; opacity:.55; }
+  .dm-vcard { display:flex; gap:0; text-decoration:none; color:inherit; }
+  .dm-vcard .cov { position:relative; flex:0 0 88px; width:88px; height:116px; background:#000; }
+  .dm-vcard .cov img { width:100%; height:100%; object-fit:cover; display:block; }
+  .dm-vcard .cov .play { position:absolute; inset:0; margin:auto; width:26px; height:26px; display:flex; align-items:center; justify-content:center; font-size:11px; color:#fff; background:rgba(0,0,0,.42); border-radius:999px; }
+  .dm-vcard .meta { flex:1; min-width:0; padding:9px 11px; display:flex; flex-direction:column; gap:6px; }
+  .dm-vcard .ttl { font-size:13px; line-height:1.35; color:var(--fg-strong); display:-webkit-box; -webkit-line-clamp:3; -webkit-box-orient:vertical; overflow:hidden; }
+  .dm-vcard .au { display:flex; align-items:center; gap:5px; margin-top:auto; font-size:11.5px; color:var(--mut); overflow:hidden; }
+  .dm-vcard .au .av { width:16px; height:16px; border-radius:999px; flex:0 0 auto; object-fit:cover; }
+  .dm-vcard .au span { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+  .dm-vcard:hover .ttl { color:var(--acc); }
   .dm-composer { display:flex; gap:8px; padding:12px; border-top:1px solid var(--line-soft); }
   .dm-composer input { flex:1; }
   .dm-composer button { flex:0 0 auto; }


### PR DESCRIPTION
## 问题
抖音私信里「分享视频」等消息显示成**空白气泡**。根因:`msg_type=8`(分享视频)、图片(27)、语音(17)等媒体消息的 content JSON 里没有 `.text` 字段,预览函数只认 `.text` 就落空,历史落库存了空文本。

## 改动
按实测标定(`DouYin_Spider/douyin_recv_msg.py` 的 msg_type→content 映射)补齐:

- **`_preview_text`** 增 `msg_type` 兜底占位(8=视频 5=表情 17=语音 27=图片),不再返回空
- **`share_video_card`** 从 content 抽 `{itemId, content_title, content_name, cover_url, secUID}`;分享视频渲染成**封面+标题+作者的可点卡片**,点击跳转抖音该视频
- 卡片数据存 `DmMessage.raw_json`(复用现成空字段,免建表迁移),历史抓取 / 实时 WS / 列表 API **三路贯通**
- **修 `.dm-bubble` flex 塌陷**:溢出的 flex 列里卡片被收缩成 2px + `overflow:hidden` 裁成一条横线 → 加 `flex:0 0 auto` 禁止压缩

## 附带
- 首页加 `no-cache` 头 + app.js 带 mtime 版本号(改前端免手动强刷)
- `fetch-history?debug=true` 回传 `media_samples`(便于标定后续新消息类型)

## 验证
用真实私信数据无头渲染:11 张视频卡片在真实条件(50 条消息 + `max-height:500px` flex 列)下全部正常显示(142px),封面图 HTTP 200 加载成功。文本/转账/表情等回归正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)