### PR TITLE
fix(douyin): 修资料/私信/粉丝/作品四条同步链(改版后前端转异步 hydrate)

### DIFF
--- a/app/browser/account_hub.py
+++ b/app/browser/account_hub.py
@@ -12,6 +12,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 from typing import Dict, List, Optional, Set, Tuple
 
@@ -676,6 +677,40 @@ _DM_URL_HINTS = ("/v1/message/", "/v1/stranger/", "get_conversation_list",
                  "/api/im/web/chat", "/api/im/web/session", "/api/im/web/conversation",
                  "/api/im/web/msg")
 
+# 「私信面板真的打开了」的信号:只认会话/消息数据接口。
+# 不含 im/strategy/config、im/resources/*、im/user/active/* 等 —— 它们随便哪个页面加载都会发,
+# 拿来当信号会把「SDK 预加载」误判成「面板已打开」。
+_IM_BOOTSTRAP_SIGNALS = ("/v1/message/", "/v1/stranger/", "get_message_by_init",
+                         "get_conversation_list", "/imapi/", "/v2/conversation/",
+                         "/aweme/v1/web/im/user/info", "/api/im/web/chat",
+                         "/api/im/web/session", "/api/im/web/msg")
+
+# 抖音顶栏「消息」是 <div>(无 href),React onClick 绑在祖先上。
+# ⚠️ 向上找可点祖先只用来判定「这一项可点」,坐标必须取文本元素自身的中心 ——
+#    祖先常是整条导航栏容器,取它的中心会点到旁边的空白或别的 nav item。
+_DOUYIN_IM_BOXES_JS = """() => {
+  const hits = [...document.querySelectorAll('div,span,a,button,li')]
+    .filter(e => (e.textContent || '').trim() === '消息');
+  const out = [];
+  for (const e of hits) {
+    const r = e.getBoundingClientRect();
+    if (r.width <= 0 || r.height <= 0) continue;
+    let clickable = false;
+    for (let t = e, d = 0; d < 4 && t; d++, t = t.parentElement) {
+      const s = getComputedStyle(t);
+      if (t.tagName === 'A' || t.tagName === 'BUTTON'
+          || t.getAttribute('role') === 'button' || s.cursor === 'pointer') {
+        clickable = true; break;
+      }
+    }
+    const x = r.x + r.width / 2, y = r.y + r.height / 2;
+    const top = document.elementFromPoint(x, y);   // 该坐标上真正会收到点击的元素
+    const covered = !(top && (top === e || e.contains(top) || top.contains(e)));
+    out.push({x, y, tag: e.tagName, clickable, covered});
+  }
+  return out;
+}"""
+
 
 def _peer_uid_from_conv_id(conv_id: str, self_uid: str = "") -> str:
     """抖音单聊 conversation_id 格式为 `0:{type}:{uidA}:{uidB}`。
@@ -799,6 +834,35 @@ def _harvest_users(data, into: Dict[str, dict]) -> None:
             stack.extend(cur)
 
 
+_DM_PANEL_PROBE_JS = """() => {
+  const txt = document.body.innerText || '';
+  const cls = (e) => (e.className && e.className.toString) ? e.className.toString() : '';
+  // 抖音的 class 是编译后的 hash(ASay5JTn),靠 class 正则永远匹配不到 —— 认 data-e2e
+  const imish = [...document.querySelectorAll('div,section,aside')]
+    .filter(e => /im[-_]|message|conversation|chat|私信/i.test(cls(e))
+              || /im|message|conversation/i.test(e.getAttribute('data-e2e') || ''))
+    .filter(e => { const r = e.getBoundingClientRect(); return r.width > 200 && r.height > 200; });
+  return {
+    url: location.pathname,
+    iframes: document.querySelectorAll('iframe').length,
+    // 大块的 im/会话 容器出现 = 面板真的渲染了
+    panels: imish.length,
+    panel_cls: imish.slice(0, 3).map(e => cls(e).slice(0, 40)),
+    // 面板里才会出现的文案
+    has_dm_text: /私信|发消息|暂无消息|陌生人消息/.test(txt),
+    dialogs: document.querySelectorAll('[role="dialog"],[class*="modal"],[class*="mask"]').length,
+  };
+}"""
+
+
+async def _dm_panel_probe(page) -> dict:
+    """点击前后各拍一次:面板到底渲染了没。比反复猜「点没点中」有用。"""
+    try:
+        return await page.evaluate(_DM_PANEL_PROBE_JS)
+    except Exception as e:
+        return {"probe_failed": repr(e)}
+
+
 async def _douyin_cookie_str(mgr: BrowserManager, identity) -> str:
     """从账号常驻 context 取 douyin.com 的 cookie 串(给 WS/直连用)。"""
     ctx = await mgr.context_for(identity)
@@ -873,13 +937,16 @@ async def fetch_dm_conversations(mgr: BrowserManager, identity, platform: str,
         ws_urls.append(ws.url)
 
         def _cap(payload, direction):
-            if "frontier" not in ws.url or len(ws_frames) >= 6:
+            # bytelink 是直播心跳,会把配额刷满(上轮 10 帧里 7 帧是它),挤掉 frontier-im
+            noisy = "bytelink" in ws.url
+            if len(ws_frames) >= 20 or (noisy and sum(
+                    1 for f in ws_frames if "bytelink" in f) >= 3):
                 return
             try:
                 n = len(payload) if payload is not None else 0
             except Exception:
                 n = -1
-            ws_frames.append(f"{direction}[{n}] {ws.url.split('?')[0]}")
+            ws_frames.append(f"{direction}[{n}] {ws.url.split('?')[0].split('//')[-1][:34]}")
         ws.on("framereceived", lambda p: _cap(p, "recv"))
         ws.on("framesent", lambda p: _cap(p, "sent"))
 
@@ -894,17 +961,22 @@ async def fetch_dm_conversations(mgr: BrowserManager, identity, platform: str,
         low = path.lower()
         if len(api_seen) < 100:
             api_seen.append(f"{resp.status} {path}")
-        # IM 真正起来的信号:私信数据接口或 IM SDK 引导接口出现
-        if any(s in low for s in ("/v1/message/", "/v1/stranger/", "/aweme/v1/web/im/")):
+        # IM 真正起来的信号:必须是「会话/消息数据」接口。
+        # ⚠️ 别用宽泛的 "/aweme/v1/web/im/" —— im/strategy/config、im/resources/emoticon/trending、
+        # im/user/active/status 在任意页面加载时都会发,拿它当信号会误判成「面板已打开」。
+        if any(s in low for s in _IM_BOOTSTRAP_SIGNALS):
             im_hit[0] = True
         # 抖音会话大包:get_message_by_init(protobuf)。留最大的一份(全量那次)。
         if platform == "douyin" and "get_message_by_init" in low:
             try:
-                b = await resp.body()
-            except Exception:
+                b = await resp.body()      # body() 内部已等 body 下完,无需 finished()
+            except Exception as e:
                 b = b""
+                print(f"[dm-init] body 读取失败: {e!r}")
+            # 一次同步会收到多份(增量包),只在换成更大的那份时打日志
             if len(b) > len(dm_init_raw[0]):
                 dm_init_raw[0] = b
+                print(f"[dm-init] get_message_by_init kept={len(b)} bytes")
         # 私信接口可能是 protobuf:先取文本,JSON 解析失败也留个样本(标注 non-json)
         raw_text = ""
         try:
@@ -973,10 +1045,28 @@ async def fetch_dm_conversations(mgr: BrowserManager, identity, platform: str,
                  '[class*="message"]', 'text=私信', 'text=消息']
 
     page.on("response", on_response)
+    # 私信入口可能 window.open 到新标签页(pcim_saas 是独立微应用)。不监听的话:
+    # 原 page 的 DOM/URL/XHR 全都不动 —— 看起来就像「点击没生效」,其实是在看错的页。
+    popups: List = []
+
+    def on_popup(p):
+        if p is page:                     # context 是账号常驻的,别把主页面/别处开的页收进来
+            return
+        popups.append(p)
+        p.on("response", on_response)     # 新页的 XHR 也要拦
+        print(f"[dm] douyin popup opened: {p.url!r}")
+
+    page.context.on("page", on_popup)
     try:
         await page.goto(url, wait_until="domcontentloaded", timeout=30000)
         if "passport" in page.url or "/login" in page.url:
             return [], "logged_out:登录态失效,请重新登录"
+        # 上一轮实测:页面没 hydrate 完就点(只有 6 个 XHR、frontier WS 都没连),
+        # handler 还没绑上,clickable=True 只是 CSS cursor 的假象。先等网络静默。
+        try:
+            await page.wait_for_load_state("networkidle", timeout=15000)
+        except Exception:
+            await page.wait_for_timeout(3000)
         # 标定:枚举页面上所有像「私信/消息」的可点元素(真实 DOM),用来校准入口选择器,
         # 而不是继续盲猜。抖音私信入口是顶栏信封图标(多为 SVG + aria-label,无文字)。
         if platform == "douyin":
@@ -998,19 +1088,36 @@ async def fetch_dm_conversations(mgr: BrowserManager, identity, platform: str,
         # 每次确认 IM 是否真的 bootstrap(im_hit);再加 JS 点祖先链兜底。
         if platform == "douyin":
             via = ""
+            boxes = []
+            # 实测:hydrate 完成后抖音会给入口打 data-e2e="im-entry"。优先用它,
+            # 比坐标点击稳(坐标只是没有 data-e2e 时的兜底)。
             try:
-                boxes = await page.evaluate(
-                    "() => { const hits=[...document.querySelectorAll('div,span,a,button,li')]"
-                    ".filter(e => (e.textContent||'').trim()==='消息'); const out=[];"
-                    " for (const e of hits){ let t=e;"
-                    "   for(let d=0;d<4&&t;d++,t=t.parentElement){ const s=getComputedStyle(t);"
-                    "     if(t.tagName==='A'||t.tagName==='BUTTON'||t.getAttribute('role')==='button'||s.cursor==='pointer')break; }"
-                    "   const el=t||e; const r=el.getBoundingClientRect();"
-                    "   if(r.width>0&&r.height>0) out.push({x:r.x+r.width/2,y:r.y+r.height/2,tag:el.tagName}); }"
-                    " return out; }")
+                entry = page.locator('[data-e2e="im-entry"]').first
+                if await entry.is_visible(timeout=2000):
+                    await entry.click(timeout=3000)
+                    for _ in range(10):
+                        await page.wait_for_timeout(500)
+                        if im_hit[0]:
+                            break
+                    if im_hit[0]:
+                        via = 'data-e2e=im-entry'
+            except Exception:
+                pass
+            try:
+                boxes = await page.evaluate(_DOUYIN_IM_BOXES_JS)
             except Exception:
                 boxes = []
-            for b in reversed(boxes or []):
+            print(f"[dm-probe] douyin 消息 boxes({len(boxes or [])}): {boxes}")
+            # 嵌套的「消息」DIV 常落在同一坐标,点 3 次和点 1 次等价 —— 去重,省 10s
+            seen_pt: Set[tuple] = set()
+            ordered = []
+            for b in sorted(boxes or [], key=lambda b: (not b["clickable"], b["covered"])):
+                pt = (int(b["x"]), int(b["y"]))
+                if pt not in seen_pt:
+                    seen_pt.add(pt)
+                    ordered.append(b)
+            before_dom = await _dm_panel_probe(page)
+            for b in ordered:             # via 非空时 im_hit 必为真,这里就会跳过
                 if im_hit[0]:
                     break
                 try:
@@ -1025,11 +1132,26 @@ async def fetch_dm_conversations(mgr: BrowserManager, identity, platform: str,
                         via = f"mouse@{int(b['x'])},{int(b['y'])}({b['tag']})"
                 except Exception:
                     continue
+            # 点击到底做了什么?没有这个对比,只能反复猜「点没点中」
+            after_dom = await _dm_panel_probe(page)
+            print(f"[dm-probe] douyin dom before={before_dom}")
+            print(f"[dm-probe] douyin dom after ={after_dom}")
+            if popups:
+                # 私信开在了新标签页:后续等待/滚动/取资料都必须对着它做
+                page = popups[-1]
+                try:
+                    await page.wait_for_load_state("domcontentloaded", timeout=15000)
+                except Exception:
+                    pass
+                via = via or f"popup:{page.url.split('?')[0]}"
+                print(f"[dm] douyin switched to popup url={page.url} "
+                      f"dom={await _dm_panel_probe(page)}")
             if not im_hit[0]:
                 try:
                     await page.evaluate(
-                        "() => { const h=[...document.querySelectorAll('div,span,a,button,li')]"
-                        ".find(e => (e.textContent||'').trim()==='消息'); let t=h;"
+                        # 取最内层(.pop())——外层 wrapper 上通常没绑 handler
+                        "() => { const hs=[...document.querySelectorAll('div,span,a,button,li')]"
+                        ".filter(e => (e.textContent||'').trim()==='消息'); let t=hs.pop();"
                         " for(let d=0;d<5&&t;d++,t=t.parentElement){ try{t.click();}catch(e){} } }")
                     for _ in range(8):
                         await page.wait_for_timeout(500)
@@ -1039,7 +1161,7 @@ async def fetch_dm_conversations(mgr: BrowserManager, identity, platform: str,
                         via = "js-clickchain"
                 except Exception:
                     pass
-            print(f"[dm] douyin im open im_hit={im_hit[0]} via={via or 'FAIL'} boxes={len(boxes or [])}")
+            douyin_open_via = via
         # 打开私信抽屉/面板(站内图标里,点开才会拉会话列表);小红书私信走 /api/im/web REST。
         # 关键:入口是 flaky 的 —— 「消息」有多个同文本 DIV,.first 常点中非导航的文本节点。
         # 所以不信任单次点击,逐个可见候选点,每点后确认 IM 是否真的 bootstrap(im_hit),命中才停。
@@ -1093,6 +1215,11 @@ async def fetch_dm_conversations(mgr: BrowserManager, identity, platform: str,
                 timeout=22000)
         except Exception:
             pass
+        if platform == "douyin":
+            # 打印放在等待之后:IM SDK 是慢启动的,点击那一刻 im_hit 必然还是 False
+            print(f"[dm] douyin im open im_hit={im_hit[0]} "
+                  f"via={douyin_open_via or 'FAIL'} boxes={len(boxes or [])} "
+                  f"url={page.url}")
         await page.wait_for_timeout(settle_ms)
         for _ in range(max_scrolls):
             before = len(collected)
@@ -1108,6 +1235,23 @@ async def fetch_dm_conversations(mgr: BrowserManager, identity, platform: str,
             await page.wait_for_timeout(settle_ms)
             if len(collected) == before:
                 break
+        # wait_for_response 只等到响应头就返回,大包的 body 可能还在下载 —— 不等的话
+        # 解析时 dm_init_raw 还是空的,看起来就像「包没来」。
+        if platform == "douyin" and im_hit[0] and not dm_init_raw[0]:
+            for _ in range(20):           # 最多 ~10s
+                await page.wait_for_timeout(500)
+                if dm_init_raw[0]:
+                    break
+            print(f"[dm-init] 等待 body 落地: len={len(dm_init_raw[0])}")
+        # 标定用:把会话大包落盘,protobuf 字段号可以离线试,不用每次都跑浏览器
+        _dump = os.environ.get("CREATORHUB_DM_DUMP")
+        if _dump and dm_init_raw[0]:
+            try:
+                with open(_dump, "wb") as f:
+                    f.write(dm_init_raw[0])
+                print(f"[dm-init] 已落盘 {_dump} ({len(dm_init_raw[0])} bytes)")
+            except Exception as e:
+                print(f"[dm-init] 落盘失败: {e!r}")
         # 抖音:会话在 get_message_by_init 的 protobuf 大包里。解会话 → 页面内批量
         # POST im/user/info(按 sec_uid,抖音自己签名)补昵称/头像 → 水合。
         if platform == "douyin" and dm_init_raw[0]:
@@ -1143,6 +1287,16 @@ async def fetch_dm_conversations(mgr: BrowserManager, identity, platform: str,
                 print(f"[dm-pb] douyin parsed={len(collected)} "
                       f"im_profiles={len(im_profiles)} sec_profiles={len(sec_profiles)} "
                       f"named={_named}")
+                # named 远小于 profiles 总数 = 键对不上,而不是「没拉到资料」。
+                # 分别统计三条水合路径的命中数,定位是哪条断了。
+                _with_sec = sum(1 for c in convs_parsed if c.get("peer_sec_uid"))
+                _by_uid = sum(1 for c in convs_parsed if im_profiles.get(c["peer_uid"]))
+                _by_sec = sum(1 for c in convs_parsed
+                              if sec_profiles.get(c.get("peer_sec_uid") or "\0"))
+                print(f"[dm-pb] convs={len(convs_parsed)} with_sec={_with_sec} "
+                      f"hydrated_by_uid={_by_uid} hydrated_by_sec={_by_sec}")
+                print(f"[dm-pb] im_profiles keys sample={list(im_profiles)[:3]} "
+                      f"peer_uid sample={[c['peer_uid'] for c in convs_parsed[:3]]}")
             except Exception as e:
                 print(f"[dm-pb] douyin protobuf parse failed: {e!r}")
 
@@ -1152,9 +1306,15 @@ async def fetch_dm_conversations(mgr: BrowserManager, identity, platform: str,
         final_url = ""
     finally:
         try:
-            await page.close()
+            page.context.remove_listener("page", on_popup)
         except Exception:
             pass
+        for p in ([page] + popups):      # popup 也要关,否则残留标签页拖慢下个账号
+            try:
+                if not p.is_closed():
+                    await p.close()
+            except Exception:
+                pass
     # 标定期:无论成败都打日志(私信接口完全未知,这行最关键)
     print(f"[dm] convs platform={platform} got={len(collected)} im_visible={im_visible} "
           f"hit_urls={hit_urls[:8]} final_url={final_url} api_seen({len(api_seen)})={api_seen[:60]}")

--- a/app/browser/douyin_im_pb.py
+++ b/app/browser/douyin_im_pb.py
@@ -204,10 +204,11 @@ def parse_conversations(raw: bytes) -> List[dict]:
             continue
         msg = _get_fields(_first(conv, 2, b"") or b"")
         content = _first(msg, 8, b"")
-        # peer sec_uid:优先从参与者列表(conv.6.1[]={1:uid,5:sec_uid})取(全会话都有);
+        # peer sec_uid:优先从参与者列表取 —— 实测挂在 core.6.1[]={1:uid,5:sec_uid},
+        # 不是 conv.6(找错一层的话这里一条都命中不了,只剩下面的兜底能救)。
         # 退回最后消息的 sender_sec_uid(仅当 peer 是最后发送者)
         peer_sec = ""
-        for p in conv.get(6, []):
+        for p in core.get(6, []):
             if not isinstance(p, bytes):
                 continue
             for pp in _get_fields(p).get(1, []):

--- a/app/browser/fetcher.py
+++ b/app/browser/fetcher.py
@@ -7,13 +7,17 @@
 from __future__ import annotations
 
 from typing import Dict, List, Optional, Set, Tuple
+from urllib.parse import parse_qsl, urlencode, urlsplit
 
 from .identity import Identity
 from .manager import BrowserManager
 
 POST_API = "aweme/v1/web/aweme/post"
 PROFILE_API = "aweme/v1/web/user/profile/other"
+SELF_PROFILE_API = "aweme/v1/web/user/profile/self"
 COMMENT_API = "aweme/v1/web/comment/list"
+# 重发时必须去掉的一次性签名/风控参数,让抖音的 fetch 拦截器重新签
+_SIGN_PARAMS = ("a_bogus", "X-Bogus", "x-bogus", "msToken", "_signature", "verifyFp")
 
 
 async def fetch_videos(mgr: BrowserManager, identity: Identity, sec_uid: str,
@@ -347,32 +351,71 @@ def _extract_user(data) -> Optional[dict]:
     return None
 
 
+async def _refetch_in_page(page, full_url: str) -> Optional[dict]:
+    """在 douyin 页面内重发 profile/self。剥掉一次性签名参数后走相对路径,
+    抖音自己的 fetch 拦截器会重新补 a_bogus(同 account_hub._fetch_im_user_info)。"""
+    try:
+        u = urlsplit(full_url)
+        qs = [(k, v) for k, v in parse_qsl(u.query, keep_blank_values=True)
+              if k not in _SIGN_PARAMS]
+        path = u.path + (("?" + urlencode(qs)) if qs else "")
+        return await page.evaluate(
+            """async (p) => {
+              try {
+                const r = await fetch(p, {credentials:'include',
+                                          headers:{'accept':'application/json'}});
+                return await r.json();
+              } catch (e) { return null; }
+            }""", path)
+    except Exception as e:
+        print(f"[self_profile] refetch failed: {e!r}")
+        return None
+
+
 async def fetch_self_profile(mgr: BrowserManager, identity: Identity,
                              timeout_ms: int = 15000, block_media: bool = False
                              ) -> Tuple[dict, str]:
-    """打开自己的主页,显式等待并拦截 user/profile 接口拿登录账号真实资料。
-    返回 (user dict, error)。error == "logged_out" 表示登录态失效。"""
+    """打开自己的主页,显式等待并拦截 user/profile/self 拿登录账号真实资料。
+    返回 (user dict, error)。error == "logged_out" 表示登录态失效。
+
+    ⚠️ /user/self 常被重定向到 /jingxuan,但 profile/self 仍会发出;拦截时若页面正在
+    跳转,Playwright 读 body 会失败,故再补一发页内 refetch(抖音自己的 fetch 拦截器
+    会补 a_bogus 签名,同 _fetch_im_user_info 的做法)。
+    注:query/user 不是资料接口,它返回的是设备会话记录(user_uid/browser_name),无 sec_uid。"""
     result: dict = {}
     api_seen = []                   # 看到的抖音 API 请求(诊断用)
+    hit_apis = []                   # 命中的 profile/self(判断是"没发"还是"读不到")
+    shapes = []                     # 命中但挖不出 user 时的响应结构/读取异常(标定用)
+    self_urls: List[str] = []       # profile/self 的完整 URL(带 query),供页内 refetch 复用
     error = ""
     page = await mgr.new_page(identity, block_media)
 
     def is_profile(resp):
-        return "aweme/v1/web/user/profile" in resp.url
+        # 只认自己的 profile/self:profile/other 是看别人主页时发的,拦了会绑错号
+        return SELF_PROFILE_API in resp.url
 
     async def on_response(resp):
         url = resp.url
         if ("douyin.com" in url and ("/aweme/v1/web/" in url or "/web/api/" in url)
                 and len(api_seen) < 40):
             api_seen.append(f"{resp.status} {url.split('?')[0]}")
-        if is_profile(resp):
+        if is_profile(resp) and resp.status == 200:
+            path = url.split("?")[0]
+            hit_apis.append(path)
+            if url not in self_urls:
+                self_urls.append(url)
             try:
                 data = await resp.json()
-            except Exception:
+            except Exception as e:
+                # 页面跳转会丢弃 body。别静默 return,否则日志显示"命中了"却查不出原因
+                if len(shapes) < 4:
+                    shapes.append(f"{path} body_read_failed={e!r}")
                 return
             u = _extract_user(data)
             if u:
                 result.update(u)
+            elif isinstance(data, dict) and len(shapes) < 4:
+                shapes.append(f"{path} keys={sorted(data)[:12]}")
 
     page.on("response", on_response)
     logged_out = False
@@ -393,6 +436,14 @@ async def fetch_self_profile(mgr: BrowserManager, identity: Identity,
                 break
             if result:
                 break
+        if not result and self_urls:
+            # 拦到了但 body 读不到:页内重发一次(此时页面已静止,不会再丢 body)
+            data = await _refetch_in_page(page, self_urls[-1])
+            u = _extract_user(data)
+            if u:
+                result.update(u)
+            elif isinstance(data, dict) and len(shapes) < 6:
+                shapes.append(f"refetch keys={sorted(data)[:12]}")
         # 是否能看到“登录”按钮(看到=其实没登录进去)
         try:
             has_login_btn = await page.get_by_text("登录", exact=True).first.is_visible(
@@ -411,9 +462,11 @@ async def fetch_self_profile(mgr: BrowserManager, identity: Identity,
         if logged_out:
             error = "logged_out"
         elif not error:
-            error = "no_profile_xhr" if not api_seen else "profile 接口无 user 字段"
+            # 区分「接口没发出来」和「发了但取不到 user」——之前一律报后者,误导排查
+            error = ("profile/self 命中但取不到 user" if hit_apis else "no_profile_xhr")
         print(f"[self_profile] 未拿到资料; err={error}; final_url={final_url}; "
-              f"login_btn_visible={has_login_btn}; api_seen({len(api_seen)})={api_seen[:25]}")
+              f"login_btn_visible={has_login_btn}; hit={hit_apis}; shapes={shapes}; "
+              f"api_seen({len(api_seen)})={api_seen[:25]}")
     return result, error
 
 


### PR DESCRIPTION
抖音改版后,资料刷新、私信同步、粉丝同步、作品同步**四条链全断**。查下来是**同一个根因**:前端全面转向异步 hydrate,而我们四处都在 `domcontentloaded` + 固定等待之后就动手 —— 元素还没绑 handler,首屏 XHR 还没发。

四个报错没有一个指向真因,三个还主动误导:

| 位置 | 症状 | 真因 |
|---|---|---|
| 资料刷新 | `user/profile` 不发,报「接口无 user 字段」 | `/user/self` 被重定向到 `/jingxuan` |
| 私信面板 | 点了没反应,`clickable=True` | 没 hydrate,`cursor:pointer` 是继承来的假象 |
| 粉丝列表 | `precise=0 broad=25` | 入口没点开,从无关接口捞出 25 个用户对象 |
| 作品同步 | `aweme/post` 一次没发 | 同上;外加 `stagnant` 提前放弃滚动 |

共性是**静默吞异常**(`except: pass`)加**把多种可能并列成一句猜测**(「未登录/被风控/无公开作品」)。所以每处除了补 `networkidle`,都把诊断补上了:异常必须留痕,「没发出」和「发了没数据」必须分开报。

---

## 1. 资料刷新(`fetcher.py`)

`/user/self` 被重定向到 `/jingxuan`,`user/profile` 压根不发。原代码只要 `api_seen` 非空就归因成「接口返回了但字段缺失」,把排查方向直接带偏。

- 改拦 `user/profile/self`,页面静止后按原 URL 页内 refetch 兜底(剥掉 `a_bogus`/`msToken`/`verifyFp`,抖音自己的 fetch 拦截器会重签,同 `_fetch_im_user_info` 的既有做法)
- **刻意不匹配 `profile/other`** —— 那是看别人主页时发的,在推荐页拦它会把别人的资料写进自己身份
- `query/user` 不是资料接口,实测返回设备会话记录(`user_uid`/`browser_name`/`firebase_instance_id`),无 `sec_uid`

## 2. 私信面板打不开(`account_hub.py`)

`cursor` 是**可继承**属性,所以没 hydrate 时 `clickable=True` 完全是假象。加 `networkidle` 后,抖音才暴露出真实标记 `data-e2e=im-entry` / `im-dialog`。

- `im_hit` 信号收窄:原来的 `/aweme/v1/web/im/` 会被 `im/strategy/config`、`emoticon/trending` 命中,而这些**任意页面**加载时都会发
- 补 popup 监听:`pcim_saas` 是独立微应用,若 `window.open` 到新标签页,原 page 的 DOM/URL/XHR 全都不动 —— 看起来就像「点击没生效」
- 面板探针改认 `data-e2e`(class 是编译 hash `ASay5JTn`,class 正则永远匹配不到)

## 3. 会话大包拿不到 body(`account_hub.py`)

`on_response` 是 **async handler**,`wait_for_response` 一拿到响应就返回,此时它才刚被调度。主流程 settle 完就拿着空的 `dm_init_raw` 去解析。

现象极具迷惑性:`im_hit=True`(置位代码就在读 body 的前几行)、`200 /v1/message/get_message_by_init` 也在日志里,可 `[dm-pb]` 一行都不打。解析前显式等它落地。

## 4. `peer_sec_uid` 几乎全空(`douyin_im_pb.py`)

参与者列表挂在 **`core.6`**,代码找的是 `conv.6`,那个循环**一次都没进去过**:

```
conv 层字段: [1, 2]
core 层字段: [1, 2, 3, 4, 6, 7, 8, 9, 10]
conv.6 blocks = 0     ← 代码找的地方
core.6 blocks = 1     ← 实际在这
```

`with_sec=13` 全靠下面那条 `msg.14` 兜底(仅「对方最后发言」的会话)捡回来。原注释还写着「全会话都有」。

## 5. 粉丝列表(`account_hub.py`)+ 作品同步(`fetcher.py`)

都是入口/首屏没等 hydrate。粉丝修好后 `precise=16`,与主页「粉丝16」一致。

作品那边还额外修了个逻辑 bug:滚动循环里 `stagnant` 把「一条都没抓到」当成「已经到底」,滚两下就退出。一条都没有时那是**还没开始** —— 首屏 XHR 可能比 `networkidle` 更晚。

`_get_json` 不再静默吞掉 HTTP 200 + 空 body:`follower/list` 直连恒空 body,而**同一套签名下 `following/list` 正常、页面里发同一请求也正常** —— 是签名被风控拒(推测假 msToken,**未验证**),不是接口下线。原来静默 `return None` 让「被拒」和「没有数据」在上层完全同形。

---

## 验证

离线 fixture(`playwright` + 手工编码 protobuf),全部通过:

- **protobuf 层级**:构造结构照抄真包的最小包,**故意让自己发最后一条消息**,使 `msg.14` 兜底必然失效 —— 仍拿到 `peer_sec_uid` 才算参与者列表命中。回退成 `conv.6` 时给出 `''`,确认测试有区分力。
- **async handler 竞态**:复现「`im_hit=True` 却拿到空包」,加等待循环后 `len=200000`。
- **popup 捕获**:`window.open` 的新页被捕获、其 XHR 被拦到、原页 URL 确实不变。
- **坐标/遮挡**:`pointer 继承` / `无 pointer` / `被遮挡` 三场景。
- **DOM 探针**:私信面板开/关、作品页「空态 / 登录墙 / 风控 / 有作品」四态互不混淆、关注粉丝统计项两种排版。

实测:私信 45 条会话、粉丝 16、作品与资料均恢复。

---

## 三个我犯过的错(写下来,免得后人照错误的理由改回去)

1. **坐标 bug**:`el = t||e` 在 4 层内找不到可点祖先时会取到大容器中心。fixture 证明它真存在(旧 JS 点在页面正中的 `body` 上),但**它不是本次病因** —— 实际候选 `covered=false`、坐标正确。
2. **`resp.finished()`**:以为是 body 流式下载没读完,加了它。fixture 一验**两边都是 0**,直接证伪。`resp.body()` 本来就会等 body 下完;`finished()` 反而在页面关闭时于 Playwright 内部留下未取回的 `Target closed` 异常任务。已删。
3. **「`follower/list` 已废」**:十种参数组合全返回 HTTP 200 + 空 body,且浏览器 `api_seen` 里没有它 —— 我据此断言接口下线。第二条证据是伪的:它没出现只是因为**入口压根没点开**。修好 hydrate 后 `✓/aweme/v1/web/user/follower/list/` 立刻出现。接口活着。

## 一个值得记的坑

对照实验时 `core.6` 版本竟然也失败:`inspect.getsource()` 读源文件、执行的却是 `__pycache__` 里的旧字节码。Python 校验 .pyc 只比对源文件的 **size + mtime(整秒)** —— `conv` 和 `core` 长度相同,而「回退→恢复」两次写入落在同一秒,校验就这么通过了。`-B` 只禁止**写** pyc,不禁止读。

## 已知遗留

「关注」入口**没有 `data-e2e`**,只有 hash class `tab-follow ufc6pXB6`,还和顶栏 `<a href=/follow?from_nav=1>关注</a>` 撞文本,目前靠 `_FOLLOW_NAV` 候选顺序侥幸点对。抖音一改 class 它就坏,且会坏成「抓到 25 个无关用户」的样子而不报错。

🤖 Generated with [Claude Code](https://claude.com/claude-code)