### PR TITLE
fix(douyin): 修粉丝/作品/关注入口(接 #10,同一个 hydrate 根因)

### DIFF
--- a/app/browser/account_hub.py
+++ b/app/browser/account_hub.py
@@ -420,7 +420,27 @@ _XHS_SCRAPE_DRAWER_JS = """(selfUid) => {
 }"""
 # 各平台 关注/粉丝 列表接口的「方向专属」URL 关键词 —— 必须互斥,否则两边混到一起。
 # 抖音:following/list vs follower/list(都含 follow,但 following 不含于 follower,反之亦然)。
+# 抖音主页「关注/粉丝」统计项:hydrate 后才有真实标记。打出来校准选择器,
+# 顺便看它是不是 <a>(能直接 goto)还是纯 div(必须点)。
+_DOUYIN_STAT_PROBE_JS = """() => {
+  const out = [];
+  for (const e of document.querySelectorAll('a,div,span,button')) {
+    const t = (e.textContent || '').trim();
+    if (!/^(关注|粉丝|获赞)\\s*\\d*$/.test(t) && !/^\\d[\\d.万亿]*\\s*(关注|粉丝)$/.test(t)) continue;
+    const r = e.getBoundingClientRect();
+    if (r.width <= 0 || r.height <= 0) continue;
+    out.push({tag: e.tagName, txt: t.slice(0, 12),
+              de: e.getAttribute('data-e2e'),
+              href: e.getAttribute('href'),
+              cls: (e.className && e.className.toString ? e.className.toString() : '').slice(0, 32)});
+  }
+  return out.slice(0, 12);
+}"""
+
 _FOLLOW_PRECISE = {
+    # follower/list 接口是活的(浏览器拦截能拿到数据),但直连拿不到:所有参数组合都是
+    # HTTP 200 + 空 body,而同一套签名下 following/list 正常。推测是假 msToken 被风控拒
+    # (未验证)。所以 fan 方向实际靠浏览器兜底,别再去调直连的参数。
     "douyin":   {"following": ("following/list",), "fan": ("follower/list",)},
     "xhs":      {"following": ("followings", "/follows"), "fan": ("fans", "/followers")},
     "kuaishou": {"following": (), "fan": ()},   # 快手走 graphql visionProfileUserList(见下)
@@ -526,7 +546,20 @@ async def fetch_follows(mgr: BrowserManager, identity, platform: str, uid: str,
         await page.goto(url, wait_until="domcontentloaded", timeout=30000)
         if "passport" in page.url or "/login" in page.url:
             return [], "logged_out:登录态失效,请重新登录"
+        # 和私信入口同一个坑:没 hydrate 完就点,React handler 还没绑,
+        # 元素「看起来可点」但点了没反应。先等网络静默。
+        try:
+            await page.wait_for_load_state("networkidle", timeout=15000)
+        except Exception:
+            pass
         await page.wait_for_timeout(settle_ms)
+        if platform == "douyin":
+            # 标定:hydrate 后把关注/粉丝入口的真实标记打出来,别再盲猜选择器
+            try:
+                print(f"[follow-probe] douyin stat entries: "
+                      f"{await page.evaluate(_DOUYIN_STAT_PROBE_JS)}")
+            except Exception as e:
+                print(f"[follow-probe] douyin probe failed: {e!r}")
         # 打开「当前方向」的列表:依次试候选入口,点完等该方向专属接口回包来确认开对了。
         openers = nav.get("open", {}).get(direction, [])
         opened = False

--- a/app/browser/account_hub.py
+++ b/app/browser/account_hub.py
@@ -12,6 +12,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 from typing import Dict, List, Optional, Set, Tuple
 
@@ -676,6 +677,40 @@ _DM_URL_HINTS = ("/v1/message/", "/v1/stranger/", "get_conversation_list",
                  "/api/im/web/chat", "/api/im/web/session", "/api/im/web/conversation",
                  "/api/im/web/msg")
 
+# 「私信面板真的打开了」的信号:只认会话/消息数据接口。
+# 不含 im/strategy/config、im/resources/*、im/user/active/* 等 —— 它们随便哪个页面加载都会发,
+# 拿来当信号会把「SDK 预加载」误判成「面板已打开」。
+_IM_BOOTSTRAP_SIGNALS = ("/v1/message/", "/v1/stranger/", "get_message_by_init",
+                         "get_conversation_list", "/imapi/", "/v2/conversation/",
+                         "/aweme/v1/web/im/user/info", "/api/im/web/chat",
+                         "/api/im/web/session", "/api/im/web/msg")
+
+# 抖音顶栏「消息」是 <div>(无 href),React onClick 绑在祖先上。
+# ⚠️ 向上找可点祖先只用来判定「这一项可点」,坐标必须取文本元素自身的中心 ——
+#    祖先常是整条导航栏容器,取它的中心会点到旁边的空白或别的 nav item。
+_DOUYIN_IM_BOXES_JS = """() => {
+  const hits = [...document.querySelectorAll('div,span,a,button,li')]
+    .filter(e => (e.textContent || '').trim() === '消息');
+  const out = [];
+  for (const e of hits) {
+    const r = e.getBoundingClientRect();
+    if (r.width <= 0 || r.height <= 0) continue;
+    let clickable = false;
+    for (let t = e, d = 0; d < 4 && t; d++, t = t.parentElement) {
+      const s = getComputedStyle(t);
+      if (t.tagName === 'A' || t.tagName === 'BUTTON'
+          || t.getAttribute('role') === 'button' || s.cursor === 'pointer') {
+        clickable = true; break;
+      }
+    }
+    const x = r.x + r.width / 2, y = r.y + r.height / 2;
+    const top = document.elementFromPoint(x, y);   // 该坐标上真正会收到点击的元素
+    const covered = !(top && (top === e || e.contains(top) || top.contains(e)));
+    out.push({x, y, tag: e.tagName, clickable, covered});
+  }
+  return out;
+}"""
+
 
 def _peer_uid_from_conv_id(conv_id: str, self_uid: str = "") -> str:
     """抖音单聊 conversation_id 格式为 `0:{type}:{uidA}:{uidB}`。
@@ -799,6 +834,35 @@ def _harvest_users(data, into: Dict[str, dict]) -> None:
             stack.extend(cur)
 
 
+_DM_PANEL_PROBE_JS = """() => {
+  const txt = document.body.innerText || '';
+  const cls = (e) => (e.className && e.className.toString) ? e.className.toString() : '';
+  // 抖音的 class 是编译后的 hash(ASay5JTn),靠 class 正则永远匹配不到 —— 认 data-e2e
+  const imish = [...document.querySelectorAll('div,section,aside')]
+    .filter(e => /im[-_]|message|conversation|chat|私信/i.test(cls(e))
+              || /im|message|conversation/i.test(e.getAttribute('data-e2e') || ''))
+    .filter(e => { const r = e.getBoundingClientRect(); return r.width > 200 && r.height > 200; });
+  return {
+    url: location.pathname,
+    iframes: document.querySelectorAll('iframe').length,
+    // 大块的 im/会话 容器出现 = 面板真的渲染了
+    panels: imish.length,
+    panel_cls: imish.slice(0, 3).map(e => cls(e).slice(0, 40)),
+    // 面板里才会出现的文案
+    has_dm_text: /私信|发消息|暂无消息|陌生人消息/.test(txt),
+    dialogs: document.querySelectorAll('[role="dialog"],[class*="modal"],[class*="mask"]').length,
+  };
+}"""
+
+
+async def _dm_panel_probe(page) -> dict:
+    """点击前后各拍一次:面板到底渲染了没。比反复猜「点没点中」有用。"""
+    try:
+        return await page.evaluate(_DM_PANEL_PROBE_JS)
+    except Exception as e:
+        return {"probe_failed": repr(e)}
+
+
 async def _douyin_cookie_str(mgr: BrowserManager, identity) -> str:
     """从账号常驻 context 取 douyin.com 的 cookie 串(给 WS/直连用)。"""
     ctx = await mgr.context_for(identity)
@@ -873,13 +937,16 @@ async def fetch_dm_conversations(mgr: BrowserManager, identity, platform: str,
         ws_urls.append(ws.url)
 
         def _cap(payload, direction):
-            if "frontier" not in ws.url or len(ws_frames) >= 6:
+            # bytelink 是直播心跳,会把配额刷满(上轮 10 帧里 7 帧是它),挤掉 frontier-im
+            noisy = "bytelink" in ws.url
+            if len(ws_frames) >= 20 or (noisy and sum(
+                    1 for f in ws_frames if "bytelink" in f) >= 3):
                 return
             try:
                 n = len(payload) if payload is not None else 0
             except Exception:
                 n = -1
-            ws_frames.append(f"{direction}[{n}] {ws.url.split('?')[0]}")
+            ws_frames.append(f"{direction}[{n}] {ws.url.split('?')[0].split('//')[-1][:34]}")
         ws.on("framereceived", lambda p: _cap(p, "recv"))
         ws.on("framesent", lambda p: _cap(p, "sent"))
 
@@ -894,17 +961,22 @@ async def fetch_dm_conversations(mgr: BrowserManager, identity, platform: str,
         low = path.lower()
         if len(api_seen) < 100:
             api_seen.append(f"{resp.status} {path}")
-        # IM 真正起来的信号:私信数据接口或 IM SDK 引导接口出现
-        if any(s in low for s in ("/v1/message/", "/v1/stranger/", "/aweme/v1/web/im/")):
+        # IM 真正起来的信号:必须是「会话/消息数据」接口。
+        # ⚠️ 别用宽泛的 "/aweme/v1/web/im/" —— im/strategy/config、im/resources/emoticon/trending、
+        # im/user/active/status 在任意页面加载时都会发,拿它当信号会误判成「面板已打开」。
+        if any(s in low for s in _IM_BOOTSTRAP_SIGNALS):
             im_hit[0] = True
         # 抖音会话大包:get_message_by_init(protobuf)。留最大的一份(全量那次)。
         if platform == "douyin" and "get_message_by_init" in low:
             try:
-                b = await resp.body()
-            except Exception:
+                b = await resp.body()      # body() 内部已等 body 下完,无需 finished()
+            except Exception as e:
                 b = b""
+                print(f"[dm-init] body 读取失败: {e!r}")
+            # 一次同步会收到多份(增量包),只在换成更大的那份时打日志
             if len(b) > len(dm_init_raw[0]):
                 dm_init_raw[0] = b
+                print(f"[dm-init] get_message_by_init kept={len(b)} bytes")
         # 私信接口可能是 protobuf:先取文本,JSON 解析失败也留个样本(标注 non-json)
         raw_text = ""
         try:
@@ -973,10 +1045,28 @@ async def fetch_dm_conversations(mgr: BrowserManager, identity, platform: str,
                  '[class*="message"]', 'text=私信', 'text=消息']
 
     page.on("response", on_response)
+    # 私信入口可能 window.open 到新标签页(pcim_saas 是独立微应用)。不监听的话:
+    # 原 page 的 DOM/URL/XHR 全都不动 —— 看起来就像「点击没生效」,其实是在看错的页。
+    popups: List = []
+
+    def on_popup(p):
+        if p is page:                     # context 是账号常驻的,别把主页面/别处开的页收进来
+            return
+        popups.append(p)
+        p.on("response", on_response)     # 新页的 XHR 也要拦
+        print(f"[dm] douyin popup opened: {p.url!r}")
+
+    page.context.on("page", on_popup)
     try:
         await page.goto(url, wait_until="domcontentloaded", timeout=30000)
         if "passport" in page.url or "/login" in page.url:
             return [], "logged_out:登录态失效,请重新登录"
+        # 上一轮实测:页面没 hydrate 完就点(只有 6 个 XHR、frontier WS 都没连),
+        # handler 还没绑上,clickable=True 只是 CSS cursor 的假象。先等网络静默。
+        try:
+            await page.wait_for_load_state("networkidle", timeout=15000)
+        except Exception:
+            await page.wait_for_timeout(3000)
         # 标定:枚举页面上所有像「私信/消息」的可点元素(真实 DOM),用来校准入口选择器,
         # 而不是继续盲猜。抖音私信入口是顶栏信封图标(多为 SVG + aria-label,无文字)。
         if platform == "douyin":
@@ -998,19 +1088,36 @@ async def fetch_dm_conversations(mgr: BrowserManager, identity, platform: str,
         # 每次确认 IM 是否真的 bootstrap(im_hit);再加 JS 点祖先链兜底。
         if platform == "douyin":
             via = ""
+            boxes = []
+            # 实测:hydrate 完成后抖音会给入口打 data-e2e="im-entry"。优先用它,
+            # 比坐标点击稳(坐标只是没有 data-e2e 时的兜底)。
             try:
-                boxes = await page.evaluate(
-                    "() => { const hits=[...document.querySelectorAll('div,span,a,button,li')]"
-                    ".filter(e => (e.textContent||'').trim()==='消息'); const out=[];"
-                    " for (const e of hits){ let t=e;"
-                    "   for(let d=0;d<4&&t;d++,t=t.parentElement){ const s=getComputedStyle(t);"
-                    "     if(t.tagName==='A'||t.tagName==='BUTTON'||t.getAttribute('role')==='button'||s.cursor==='pointer')break; }"
-                    "   const el=t||e; const r=el.getBoundingClientRect();"
-                    "   if(r.width>0&&r.height>0) out.push({x:r.x+r.width/2,y:r.y+r.height/2,tag:el.tagName}); }"
-                    " return out; }")
+                entry = page.locator('[data-e2e="im-entry"]').first
+                if await entry.is_visible(timeout=2000):
+                    await entry.click(timeout=3000)
+                    for _ in range(10):
+                        await page.wait_for_timeout(500)
+                        if im_hit[0]:
+                            break
+                    if im_hit[0]:
+                        via = 'data-e2e=im-entry'
+            except Exception:
+                pass
+            try:
+                boxes = await page.evaluate(_DOUYIN_IM_BOXES_JS)
             except Exception:
                 boxes = []
-            for b in reversed(boxes or []):
+            print(f"[dm-probe] douyin 消息 boxes({len(boxes or [])}): {boxes}")
+            # 嵌套的「消息」DIV 常落在同一坐标,点 3 次和点 1 次等价 —— 去重,省 10s
+            seen_pt: Set[tuple] = set()
+            ordered = []
+            for b in sorted(boxes or [], key=lambda b: (not b["clickable"], b["covered"])):
+                pt = (int(b["x"]), int(b["y"]))
+                if pt not in seen_pt:
+                    seen_pt.add(pt)
+                    ordered.append(b)
+            before_dom = await _dm_panel_probe(page)
+            for b in ordered:             # via 非空时 im_hit 必为真,这里就会跳过
                 if im_hit[0]:
                     break
                 try:
@@ -1025,11 +1132,26 @@ async def fetch_dm_conversations(mgr: BrowserManager, identity, platform: str,
                         via = f"mouse@{int(b['x'])},{int(b['y'])}({b['tag']})"
                 except Exception:
                     continue
+            # 点击到底做了什么?没有这个对比,只能反复猜「点没点中」
+            after_dom = await _dm_panel_probe(page)
+            print(f"[dm-probe] douyin dom before={before_dom}")
+            print(f"[dm-probe] douyin dom after ={after_dom}")
+            if popups:
+                # 私信开在了新标签页:后续等待/滚动/取资料都必须对着它做
+                page = popups[-1]
+                try:
+                    await page.wait_for_load_state("domcontentloaded", timeout=15000)
+                except Exception:
+                    pass
+                via = via or f"popup:{page.url.split('?')[0]}"
+                print(f"[dm] douyin switched to popup url={page.url} "
+                      f"dom={await _dm_panel_probe(page)}")
             if not im_hit[0]:
                 try:
                     await page.evaluate(
-                        "() => { const h=[...document.querySelectorAll('div,span,a,button,li')]"
-                        ".find(e => (e.textContent||'').trim()==='消息'); let t=h;"
+                        # 取最内层(.pop())——外层 wrapper 上通常没绑 handler
+                        "() => { const hs=[...document.querySelectorAll('div,span,a,button,li')]"
+                        ".filter(e => (e.textContent||'').trim()==='消息'); let t=hs.pop();"
                         " for(let d=0;d<5&&t;d++,t=t.parentElement){ try{t.click();}catch(e){} } }")
                     for _ in range(8):
                         await page.wait_for_timeout(500)
@@ -1039,7 +1161,7 @@ async def fetch_dm_conversations(mgr: BrowserManager, identity, platform: str,
                         via = "js-clickchain"
                 except Exception:
                     pass
-            print(f"[dm] douyin im open im_hit={im_hit[0]} via={via or 'FAIL'} boxes={len(boxes or [])}")
+            douyin_open_via = via
         # 打开私信抽屉/面板(站内图标里,点开才会拉会话列表);小红书私信走 /api/im/web REST。
         # 关键:入口是 flaky 的 —— 「消息」有多个同文本 DIV,.first 常点中非导航的文本节点。
         # 所以不信任单次点击,逐个可见候选点,每点后确认 IM 是否真的 bootstrap(im_hit),命中才停。
@@ -1093,6 +1215,11 @@ async def fetch_dm_conversations(mgr: BrowserManager, identity, platform: str,
                 timeout=22000)
         except Exception:
             pass
+        if platform == "douyin":
+            # 打印放在等待之后:IM SDK 是慢启动的,点击那一刻 im_hit 必然还是 False
+            print(f"[dm] douyin im open im_hit={im_hit[0]} "
+                  f"via={douyin_open_via or 'FAIL'} boxes={len(boxes or [])} "
+                  f"url={page.url}")
         await page.wait_for_timeout(settle_ms)
         for _ in range(max_scrolls):
             before = len(collected)
@@ -1108,6 +1235,23 @@ async def fetch_dm_conversations(mgr: BrowserManager, identity, platform: str,
             await page.wait_for_timeout(settle_ms)
             if len(collected) == before:
                 break
+        # wait_for_response 只等到响应头就返回,大包的 body 可能还在下载 —— 不等的话
+        # 解析时 dm_init_raw 还是空的,看起来就像「包没来」。
+        if platform == "douyin" and im_hit[0] and not dm_init_raw[0]:
+            for _ in range(20):           # 最多 ~10s
+                await page.wait_for_timeout(500)
+                if dm_init_raw[0]:
+                    break
+            print(f"[dm-init] 等待 body 落地: len={len(dm_init_raw[0])}")
+        # 标定用:把会话大包落盘,protobuf 字段号可以离线试,不用每次都跑浏览器
+        _dump = os.environ.get("CREATORHUB_DM_DUMP")
+        if _dump and dm_init_raw[0]:
+            try:
+                with open(_dump, "wb") as f:
+                    f.write(dm_init_raw[0])
+                print(f"[dm-init] 已落盘 {_dump} ({len(dm_init_raw[0])} bytes)")
+            except Exception as e:
+                print(f"[dm-init] 落盘失败: {e!r}")
         # 抖音:会话在 get_message_by_init 的 protobuf 大包里。解会话 → 页面内批量
         # POST im/user/info(按 sec_uid,抖音自己签名)补昵称/头像 → 水合。
         if platform == "douyin" and dm_init_raw[0]:
@@ -1143,6 +1287,16 @@ async def fetch_dm_conversations(mgr: BrowserManager, identity, platform: str,
                 print(f"[dm-pb] douyin parsed={len(collected)} "
                       f"im_profiles={len(im_profiles)} sec_profiles={len(sec_profiles)} "
                       f"named={_named}")
+                # named 远小于 profiles 总数 = 键对不上,而不是「没拉到资料」。
+                # 分别统计三条水合路径的命中数,定位是哪条断了。
+                _with_sec = sum(1 for c in convs_parsed if c.get("peer_sec_uid"))
+                _by_uid = sum(1 for c in convs_parsed if im_profiles.get(c["peer_uid"]))
+                _by_sec = sum(1 for c in convs_parsed
+                              if sec_profiles.get(c.get("peer_sec_uid") or "\0"))
+                print(f"[dm-pb] convs={len(convs_parsed)} with_sec={_with_sec} "
+                      f"hydrated_by_uid={_by_uid} hydrated_by_sec={_by_sec}")
+                print(f"[dm-pb] im_profiles keys sample={list(im_profiles)[:3]} "
+                      f"peer_uid sample={[c['peer_uid'] for c in convs_parsed[:3]]}")
             except Exception as e:
                 print(f"[dm-pb] douyin protobuf parse failed: {e!r}")
 
@@ -1152,9 +1306,15 @@ async def fetch_dm_conversations(mgr: BrowserManager, identity, platform: str,
         final_url = ""
     finally:
         try:
-            await page.close()
+            page.context.remove_listener("page", on_popup)
         except Exception:
             pass
+        for p in ([page] + popups):      # popup 也要关,否则残留标签页拖慢下个账号
+            try:
+                if not p.is_closed():
+                    await p.close()
+            except Exception:
+                pass
     # 标定期:无论成败都打日志(私信接口完全未知,这行最关键)
     print(f"[dm] convs platform={platform} got={len(collected)} im_visible={im_visible} "
           f"hit_urls={hit_urls[:8]} final_url={final_url} api_seen({len(api_seen)})={api_seen[:60]}")

--- a/app/browser/account_hub.py
+++ b/app/browser/account_hub.py
@@ -328,12 +328,15 @@ def _norm_follow_user(d: dict, direction: str) -> Optional[dict]:
 # 关键:关注与粉丝要点不同入口,否则两边抓到同一份(改版时改 open 候选)。
 _FOLLOW_NAV = {
     "douyin": {
+        # ⚠️ 顶栏有「关注」feed 导航(<a href="/follow?from_nav=1">,带未读角标),会和主页
+        # 统计项撞文本 —— 'text=关注' 的 .first 常点中它。dyjs: 锚定确定存在的
+        # [data-e2e="user-info-fans"],反查统计容器,只在容器内点,天然避开顶栏。
         "url": "https://www.douyin.com/user/self",
         "open": {
-            "following": ['[data-e2e="user-info-follow"]', '[data-e2e="user-following"]',
-                          'text=关注'],
-            "fan":       ['[data-e2e="user-info-fans"]', '[data-e2e="user-fans"]',
-                          'text=粉丝'],
+            "following": ['dyjs:关注', '[data-e2e="user-info-follow"]',
+                          '[data-e2e="user-following"]'],
+            "fan":       ['dyjs:粉丝', '[data-e2e="user-info-fans"]',
+                          '[data-e2e="user-fans"]'],
         },
     },
     "xhs": {
@@ -346,6 +349,34 @@ _FOLLOW_NAV = {
         "open": {"following": ['text=关注'], "fan": ['text=粉丝']},
     },
 }
+# 抖音:主页统计区里「关注」没有 data-e2e(只有编译 hash class),而「粉丝/获赞」有。
+# 所以拿 user-info-fans 当锚点:向上找到同时含「关注」「粉丝」的最小容器(= 统计区),
+# 再在容器内点目标项。顶栏的「关注」导航不在这个容器里,天然被排除。
+_DOUYIN_OPEN_STAT_JS = """(label) => {
+  const anchor = document.querySelector('[data-e2e="user-info-fans"]');
+  if (!anchor) return '';
+  // 向上找最小的、同时包含「关注」和「粉丝」的祖先 —— 那就是统计区
+  let box = anchor;
+  for (let d = 0; d < 6 && box; d++, box = box.parentElement) {
+    const t = box.textContent || '';
+    if (t.includes('关注') && t.includes('粉丝')) break;
+  }
+  if (!box) return '';
+  // 容器内找目标项:文本形如「关注22」/「22关注」
+  const re = new RegExp('^(' + label + '\\\\s*[\\\\d.万亿]*|[\\\\d.万亿]+\\\\s*' + label + ')$');
+  const hits = [...box.querySelectorAll('div,span,a')]
+    .filter(e => re.test((e.textContent || '').trim()))
+    .filter(e => { const r = e.getBoundingClientRect(); return r.width > 0 && r.height > 0; });
+  if (!hits.length) return '';
+  // 「关注」这个纯文本标签也会匹配(数字部分可为空),它只是 label,handler 在带数字的
+  // 统计项上。优先带数字的最内层;真没有数字(计数为 0 被隐藏)才退回最内层。
+  const withNum = hits.filter(e => /\\d/.test(e.textContent || ''));
+  const pool = withNum.length ? withNum : hits;
+  const el = pool[pool.length - 1];          // 最内层
+  el.click();
+  return (el.tagName + ':' + (el.textContent || '').trim()).slice(0, 40);
+}"""
+
 # 小红书:主页统计里「关注/粉丝」文案会和顶栏导航「关注」撞,用 JS 只点「紧挨数字、且不在
 # 顶栏/侧栏」的那个统计项(点它才会弹出关注/粉丝列表抽屉,进而触发列表接口)。
 _XHS_OPEN_STAT_JS = """(label) => {
@@ -565,7 +596,13 @@ async def fetch_follows(mgr: BrowserManager, identity, platform: str, uid: str,
         opened = False
         for cand in openers:
             try:
-                if cand.startswith("js:"):
+                if cand.startswith("dyjs:"):
+                    # 抖音:锚定 user-info-fans 反查统计区,只在区内点(避开顶栏「关注」导航)
+                    clicked = await page.evaluate(_DOUYIN_OPEN_STAT_JS, cand[5:])
+                    print(f"[follow] douyin stat click {cand[5:]} → {clicked!r}")
+                    if not clicked:
+                        continue
+                elif cand.startswith("js:"):
                     # 小红书:JS 精确点主页统计区的「关注/粉丝」(避开顶栏同名标签)
                     clicked = await page.evaluate(_XHS_OPEN_STAT_JS, cand[3:])
                     if not clicked:

--- a/app/browser/douyin_im_pb.py
+++ b/app/browser/douyin_im_pb.py
@@ -204,10 +204,11 @@ def parse_conversations(raw: bytes) -> List[dict]:
             continue
         msg = _get_fields(_first(conv, 2, b"") or b"")
         content = _first(msg, 8, b"")
-        # peer sec_uid:优先从参与者列表(conv.6.1[]={1:uid,5:sec_uid})取(全会话都有);
+        # peer sec_uid:优先从参与者列表取 —— 实测挂在 core.6.1[]={1:uid,5:sec_uid},
+        # 不是 conv.6(找错一层的话这里一条都命中不了,只剩下面的兜底能救)。
         # 退回最后消息的 sender_sec_uid(仅当 peer 是最后发送者)
         peer_sec = ""
-        for p in conv.get(6, []):
+        for p in core.get(6, []):
             if not isinstance(p, bytes):
                 continue
             for pp in _get_fields(p).get(1, []):

--- a/app/browser/fetcher.py
+++ b/app/browser/fetcher.py
@@ -20,6 +20,24 @@ COMMENT_API = "aweme/v1/web/comment/list"
 _SIGN_PARAMS = ("a_bogus", "X-Bogus", "x-bogus", "msToken", "_signature", "verifyFp")
 
 
+# 作品页没拿到数据时,看页面究竟是什么状态:登录墙?空态?还是 tab 没激活?
+_WORKS_DOM_PROBE_JS = """() => {
+  const txt = (document.body.innerText || '').replace(/\\s+/g, ' ');
+  const tabs = [...document.querySelectorAll('[data-e2e*="tab"],[class*="tab"]')]
+    .map(e => (e.textContent || '').trim().slice(0, 8))
+    .filter(t => t && t.length <= 8).slice(0, 8);
+  return {
+    tabs: [...new Set(tabs)],
+    items: document.querySelectorAll('[data-e2e="user-post-list"] li, li[data-e2e]').length,
+    // 这几种文案能把「空态 / 登录墙 / 风控」区分开
+    empty: /暂无作品|还没有发布|没有更多了/.test(txt),
+    login_wall: /登录后查看|立即登录|扫码登录/.test(txt),
+    risk: /访问频繁|环境异常|验证/.test(txt),
+    body_len: txt.length,
+  };
+}"""
+
+
 async def fetch_videos(mgr: BrowserManager, identity: Identity, sec_uid: str,
                        known_ids: Set[str], max_scrolls: int = 12,
                        settle_ms: int = 1800, block_media: bool = True
@@ -28,33 +46,52 @@ async def fetch_videos(mgr: BrowserManager, identity: Identity, sec_uid: str,
     collected: Dict[str, dict] = {}
     author: Optional[dict] = None
     error = ""
+    post_hits = []        # 命中的 aweme/post 响应(判断是「没发」还是「发了解不出」)
+    api_seen = []         # 该页发出的抖音 API(post_hits 为空时,靠它看页面到底在请求什么)
 
     page = await mgr.new_page(identity, block_media)
 
     async def on_response(resp):
         nonlocal author
         url = resp.url
-        try:
-            if POST_API in url:
+        if ("douyin.com" in url and ("/aweme/v1/web/" in url or "/web/api/" in url)
+                and len(api_seen) < 40):
+            api_seen.append(f"{resp.status} {url.split('?')[0].split('douyin.com')[-1]}")
+        if POST_API in url:
+            try:
                 data = await resp.json()
-                for it in (data.get("aweme_list") or []):
-                    aid = str(it.get("aweme_id") or "")
-                    if aid:
-                        collected[aid] = it
-                        if author is None and it.get("author"):
-                            author = it["author"]
-            elif PROFILE_API in url and author is None:
+            except Exception as e:
+                # 页面跳转会丢弃 body。别静默 pass,否则「200 却没数据」永远查不出原因
+                post_hits.append(f"{resp.status} body_read_failed={e!r}")
+                return
+            lst = data.get("aweme_list")
+            post_hits.append(f"{resp.status} status_code={data.get('status_code')} "
+                             f"aweme_list={len(lst) if isinstance(lst, list) else lst!r} "
+                             f"keys={sorted(data)[:8]}")
+            for it in (lst or []):
+                aid = str(it.get("aweme_id") or "")
+                if aid:
+                    collected[aid] = it
+                    if author is None and it.get("author"):
+                        author = it["author"]
+        elif PROFILE_API in url and author is None:
+            try:
                 data = await resp.json()
-                if data.get("user"):
-                    author = data["user"]
-        except Exception:
-            pass
+            except Exception:
+                return
+            if data.get("user"):
+                author = data["user"]
 
     page.on("response", on_response)
 
     try:
         await page.goto(f"https://www.douyin.com/user/{sec_uid}",
                         wait_until="domcontentloaded", timeout=30000)
+        # 同私信/粉丝入口:没 hydrate 完,作品列表的分页请求根本不会发
+        try:
+            await page.wait_for_load_state("networkidle", timeout=15000)
+        except Exception:
+            pass
         await page.wait_for_timeout(settle_ms)
         stagnant = 0
         for _ in range(max_scrolls):
@@ -64,8 +101,10 @@ async def fetch_videos(mgr: BrowserManager, identity: Identity, sec_uid: str,
             await page.mouse.wheel(0, 4000)
             await page.wait_for_timeout(settle_ms)
             if len(collected) == before:               # 本次下滑无新增
+                # 一条都没抓到时别提前退:那是「还没开始」,不是「已经到底」。
+                # 首屏 XHR 可能比 networkidle 更晚,滚满 max_scrolls 再放弃。
                 stagnant += 1
-                if stagnant >= 2:                      # 连续两次到底,停
+                if collected and stagnant >= 2:        # 连续两次到底,停
                     break
             else:
                 stagnant = 0
@@ -74,11 +113,23 @@ async def fetch_videos(mgr: BrowserManager, identity: Identity, sec_uid: str,
     except Exception as e:
         error = f"打开主页失败: {e!r}"
     finally:
+        final_url = page.url
+        dom = {}
+        if not collected:
+            try:                        # 页面到底渲染成什么样了(tab?空态?登录墙?)
+                dom = await page.evaluate(_WORKS_DOM_PROBE_JS)
+            except Exception as e:
+                dom = {"probe_failed": repr(e)}
         try:
             await page.close()
         except Exception:
             pass
 
+    if not collected:
+        # 「aweme/post 没发出来」和「发了但 aweme_list 空/读不到」是两回事,原来一律报同一句话
+        print(f"[works] 未拿到作品; sec_uid={sec_uid[:24]}… final_url={final_url}; "
+              f"post_hits({len(post_hits)})={post_hits[:5]}; dom={dom}")
+        print(f"[works] api_seen({len(api_seen)})={api_seen[:30]}")
     new_items = [it for aid, it in collected.items() if aid not in known_ids]
     return new_items, author, error
 

--- a/app/browser/fetcher.py
+++ b/app/browser/fetcher.py
@@ -7,13 +7,17 @@
 from __future__ import annotations
 
 from typing import Dict, List, Optional, Set, Tuple
+from urllib.parse import parse_qsl, urlencode, urlsplit
 
 from .identity import Identity
 from .manager import BrowserManager
 
 POST_API = "aweme/v1/web/aweme/post"
 PROFILE_API = "aweme/v1/web/user/profile/other"
+SELF_PROFILE_API = "aweme/v1/web/user/profile/self"
 COMMENT_API = "aweme/v1/web/comment/list"
+# 重发时必须去掉的一次性签名/风控参数,让抖音的 fetch 拦截器重新签
+_SIGN_PARAMS = ("a_bogus", "X-Bogus", "x-bogus", "msToken", "_signature", "verifyFp")
 
 
 async def fetch_videos(mgr: BrowserManager, identity: Identity, sec_uid: str,
@@ -347,32 +351,71 @@ def _extract_user(data) -> Optional[dict]:
     return None
 
 
+async def _refetch_in_page(page, full_url: str) -> Optional[dict]:
+    """在 douyin 页面内重发 profile/self。剥掉一次性签名参数后走相对路径,
+    抖音自己的 fetch 拦截器会重新补 a_bogus(同 account_hub._fetch_im_user_info)。"""
+    try:
+        u = urlsplit(full_url)
+        qs = [(k, v) for k, v in parse_qsl(u.query, keep_blank_values=True)
+              if k not in _SIGN_PARAMS]
+        path = u.path + (("?" + urlencode(qs)) if qs else "")
+        return await page.evaluate(
+            """async (p) => {
+              try {
+                const r = await fetch(p, {credentials:'include',
+                                          headers:{'accept':'application/json'}});
+                return await r.json();
+              } catch (e) { return null; }
+            }""", path)
+    except Exception as e:
+        print(f"[self_profile] refetch failed: {e!r}")
+        return None
+
+
 async def fetch_self_profile(mgr: BrowserManager, identity: Identity,
                              timeout_ms: int = 15000, block_media: bool = False
                              ) -> Tuple[dict, str]:
-    """打开自己的主页,显式等待并拦截 user/profile 接口拿登录账号真实资料。
-    返回 (user dict, error)。error == "logged_out" 表示登录态失效。"""
+    """打开自己的主页,显式等待并拦截 user/profile/self 拿登录账号真实资料。
+    返回 (user dict, error)。error == "logged_out" 表示登录态失效。
+
+    ⚠️ /user/self 常被重定向到 /jingxuan,但 profile/self 仍会发出;拦截时若页面正在
+    跳转,Playwright 读 body 会失败,故再补一发页内 refetch(抖音自己的 fetch 拦截器
+    会补 a_bogus 签名,同 _fetch_im_user_info 的做法)。
+    注:query/user 不是资料接口,它返回的是设备会话记录(user_uid/browser_name),无 sec_uid。"""
     result: dict = {}
     api_seen = []                   # 看到的抖音 API 请求(诊断用)
+    hit_apis = []                   # 命中的 profile/self(判断是"没发"还是"读不到")
+    shapes = []                     # 命中但挖不出 user 时的响应结构/读取异常(标定用)
+    self_urls: List[str] = []       # profile/self 的完整 URL(带 query),供页内 refetch 复用
     error = ""
     page = await mgr.new_page(identity, block_media)
 
     def is_profile(resp):
-        return "aweme/v1/web/user/profile" in resp.url
+        # 只认自己的 profile/self:profile/other 是看别人主页时发的,拦了会绑错号
+        return SELF_PROFILE_API in resp.url
 
     async def on_response(resp):
         url = resp.url
         if ("douyin.com" in url and ("/aweme/v1/web/" in url or "/web/api/" in url)
                 and len(api_seen) < 40):
             api_seen.append(f"{resp.status} {url.split('?')[0]}")
-        if is_profile(resp):
+        if is_profile(resp) and resp.status == 200:
+            path = url.split("?")[0]
+            hit_apis.append(path)
+            if url not in self_urls:
+                self_urls.append(url)
             try:
                 data = await resp.json()
-            except Exception:
+            except Exception as e:
+                # 页面跳转会丢弃 body。别静默 return,否则日志显示"命中了"却查不出原因
+                if len(shapes) < 4:
+                    shapes.append(f"{path} body_read_failed={e!r}")
                 return
             u = _extract_user(data)
             if u:
                 result.update(u)
+            elif isinstance(data, dict) and len(shapes) < 4:
+                shapes.append(f"{path} keys={sorted(data)[:12]}")
 
     page.on("response", on_response)
     logged_out = False
@@ -393,6 +436,14 @@ async def fetch_self_profile(mgr: BrowserManager, identity: Identity,
                 break
             if result:
                 break
+        if not result and self_urls:
+            # 拦到了但 body 读不到:页内重发一次(此时页面已静止,不会再丢 body)
+            data = await _refetch_in_page(page, self_urls[-1])
+            u = _extract_user(data)
+            if u:
+                result.update(u)
+            elif isinstance(data, dict) and len(shapes) < 6:
+                shapes.append(f"refetch keys={sorted(data)[:12]}")
         # 是否能看到“登录”按钮(看到=其实没登录进去)
         try:
             has_login_btn = await page.get_by_text("登录", exact=True).first.is_visible(
@@ -411,9 +462,11 @@ async def fetch_self_profile(mgr: BrowserManager, identity: Identity,
         if logged_out:
             error = "logged_out"
         elif not error:
-            error = "no_profile_xhr" if not api_seen else "profile 接口无 user 字段"
+            # 区分「接口没发出来」和「发了但取不到 user」——之前一律报后者,误导排查
+            error = ("profile/self 命中但取不到 user" if hit_apis else "no_profile_xhr")
         print(f"[self_profile] 未拿到资料; err={error}; final_url={final_url}; "
-              f"login_btn_visible={has_login_btn}; api_seen({len(api_seen)})={api_seen[:25]}")
+              f"login_btn_visible={has_login_btn}; hit={hit_apis}; shapes={shapes}; "
+              f"api_seen({len(api_seen)})={api_seen[:25]}")
     return result, error
 
 

--- a/app/platforms/douyin/client.py
+++ b/app/platforms/douyin/client.py
@@ -89,10 +89,16 @@ class DouyinClient:
             r = await cli.get(url, headers=self._headers(referer),
                               impersonate=self.impersonate, timeout=self.timeout)
             if r.status_code != 200 or not r.content:
+                # HTTP 200 + 空 body = 被风控拒了(接口本身可能是活的:follower/list 直连
+                # 空 body,页面里发同一个请求却正常)。静默 return None 会让上层把「被拒」
+                # 和「没有数据」混为一谈 —— 那正是 raw=0 查了半天的原因。
+                print(f"[dy-client] {path} → HTTP {r.status_code} len={len(r.content)}"
+                      f"{' (空 body:多半被风控拒,非无数据)' if r.status_code == 200 else ''}")
                 return None
             try:
                 return r.json()
             except Exception:
+                print(f"[dy-client] {path} → 非 JSON len={len(r.content)}")
                 return None
 
     # ── 用户资料(对应 NativeClient.FetchProfile)──


### PR DESCRIPTION
接 #10。那个 PR 只合进了「资料刷新 + 私信同步」,后续三处修复没赶上合并,单独提上来。

同一个根因:抖音改版后前端转向异步 hydrate,而我们在 `domcontentloaded` + 固定等待之后就动手 —— 元素还没绑 handler,首屏 XHR 还没发。

## 1. 粉丝列表(`account_hub.py`)

`fetch_follows` 没等 hydrate 就去点「粉丝」,列表压根没打开。

`precise=0 broad=25` 是彻头彻尾的假象 —— `_harvest_user_lists` 从 `aweme/post`、`aweme/favorite`、`im/spotlight/relation` 里捞出 25 个无关用户对象,凑得像模像样。加 `networkidle` 后 `follower/list` 正常回包,`precise=16`,与主页「粉丝16」一致。

顺带加 `_DOUYIN_STAT_PROBE_JS`,打印关注/粉丝入口的真实标记。

## 2. `_get_json` 不再静默吞掉 HTTP 200 + 空 body(`platforms/douyin/client.py`)

`follower/list` 直连恒空 body,而**同一套签名下 `following/list` 正常、页面里发同一请求也正常** —— 是签名被风控拒(推测假 msToken,**未验证**),不是接口下线。

原来静默 `return None` 让「被拒」和「没有数据」在上层完全同形,`raw=0` 什么都说明不了。

> 我一度据此断言「`follower/list` 已废」。证据之一是伪的:浏览器 `api_seen` 里没有它,只是因为**入口压根没点开**。修好 hydrate 后 `✓/aweme/v1/web/user/follower/list/` 立刻出现。

## 3. 作品同步(`fetcher.py`)

`/user/{sec_uid}` 上 `aweme/post` 一次都没发(`post_hits=0`),而 `/user/self` 上是 200。补 `networkidle` 后恢复。

另修一个逻辑 bug:滚动循环里 `stagnant` 把「一条都没抓到」当成「已经到底」,滚两下就退出。一条都没有时那是**还没开始** —— 首屏 XHR 可能比 `networkidle` 更晚。

诊断(仅在拿不到作品时打印):`aweme/post` 的 `resp.json()` 异常不再静默 `pass`;加 `api_seen`;加 `_WORKS_DOM_PROBE_JS` 把「空态 / 登录墙 / 风控 / 有作品」四种页面状态分开 —— 原报错文案把三种猜测并列(「未登录/被风控/无公开作品」),一个都没验证。

## 4. 关注入口钉到统计区(`account_hub.py`)

主页统计区里「关注」**没有 `data-e2e`**(只有编译 hash class `kCzNsmN5`),而顶栏有个「关注」feed 导航(`<a href=/follow?from_nav=1>`,带未读角标),两者文本相同。原候选里的 `text=关注` 用 `.first` 常点中顶栏,且会坏成「抓到 25 个无关用户」的样子而**不报错**。

改为锚定确定存在的 `[data-e2e=user-info-fans]`,向上找同时含「关注」「粉丝」的最小容器(= 统计区),只在容器内点。顶栏不在容器里,天然排除,不依赖任何未知标记。

注意:统计区里「关注」这个纯文本 label 也匹配(正则数字部分可为空),但 handler 在带数字的统计项上 —— 优先选带数字的最内层。

## 验证

六个离线 fixture(`playwright` + 手工编码 protobuf)全绿:

- **关注入口**:点中统计区「关注22」/「粉丝16」、顶栏**零点击**、无锚点(未 hydrate)时安全返回空而不乱点
- **作品页状态**:「空态 / 登录墙 / 风控 / 有作品」四态互不混淆
- **统计项探针**:两种排版(`关注 22` / `1234 粉丝`)命中,隐藏元素与正文排除
- 另含 #10 的三个:protobuf 层级、async handler 竞态、popup 捕获

实测:粉丝 16、作品与资料均恢复。

另有一层既有保险:点完要等 `following/list` 或 `follower/list` 回包才算 `opened`。就算 `dyjs` 哪天点歪,也不会把粉丝当关注写进库,而是换下一个候选。

🤖 Generated with [Claude Code](https://claude.com/claude-code)