### PR TITLE
fix(douyin): 修粉丝/作品/关注入口(接 #10,同一个 hydrate 根因)

### DIFF
--- a/app/browser/account_hub.py
+++ b/app/browser/account_hub.py
@@ -420,7 +420,27 @@ _XHS_SCRAPE_DRAWER_JS = """(selfUid) => {
 }"""
 # 各平台 关注/粉丝 列表接口的「方向专属」URL 关键词 —— 必须互斥,否则两边混到一起。
 # 抖音:following/list vs follower/list(都含 follow,但 following 不含于 follower,反之亦然)。
+# 抖音主页「关注/粉丝」统计项:hydrate 后才有真实标记。打出来校准选择器,
+# 顺便看它是不是 <a>(能直接 goto)还是纯 div(必须点)。
+_DOUYIN_STAT_PROBE_JS = """() => {
+  const out = [];
+  for (const e of document.querySelectorAll('a,div,span,button')) {
+    const t = (e.textContent || '').trim();
+    if (!/^(关注|粉丝|获赞)\\s*\\d*$/.test(t) && !/^\\d[\\d.万亿]*\\s*(关注|粉丝)$/.test(t)) continue;
+    const r = e.getBoundingClientRect();
+    if (r.width <= 0 || r.height <= 0) continue;
+    out.push({tag: e.tagName, txt: t.slice(0, 12),
+              de: e.getAttribute('data-e2e'),
+              href: e.getAttribute('href'),
+              cls: (e.className && e.className.toString ? e.className.toString() : '').slice(0, 32)});
+  }
+  return out.slice(0, 12);
+}"""
+
 _FOLLOW_PRECISE = {
+    # follower/list 接口是活的(浏览器拦截能拿到数据),但直连拿不到:所有参数组合都是
+    # HTTP 200 + 空 body,而同一套签名下 following/list 正常。推测是假 msToken 被风控拒
+    # (未验证)。所以 fan 方向实际靠浏览器兜底,别再去调直连的参数。
     "douyin":   {"following": ("following/list",), "fan": ("follower/list",)},
     "xhs":      {"following": ("followings", "/follows"), "fan": ("fans", "/followers")},
     "kuaishou": {"following": (), "fan": ()},   # 快手走 graphql visionProfileUserList(见下)
@@ -526,7 +546,20 @@ async def fetch_follows(mgr: BrowserManager, identity, platform: str, uid: str,
         await page.goto(url, wait_until="domcontentloaded", timeout=30000)
         if "passport" in page.url or "/login" in page.url:
             return [], "logged_out:登录态失效,请重新登录"
+        # 和私信入口同一个坑:没 hydrate 完就点,React handler 还没绑,
+        # 元素「看起来可点」但点了没反应。先等网络静默。
+        try:
+            await page.wait_for_load_state("networkidle", timeout=15000)
+        except Exception:
+            pass
         await page.wait_for_timeout(settle_ms)
+        if platform == "douyin":
+            # 标定:hydrate 后把关注/粉丝入口的真实标记打出来,别再盲猜选择器
+            try:
+                print(f"[follow-probe] douyin stat entries: "
+                      f"{await page.evaluate(_DOUYIN_STAT_PROBE_JS)}")
+            except Exception as e:
+                print(f"[follow-probe] douyin probe failed: {e!r}")
         # 打开「当前方向」的列表:依次试候选入口,点完等该方向专属接口回包来确认开对了。
         openers = nav.get("open", {}).get(direction, [])
         opened = False

--- a/app/browser/account_hub.py
+++ b/app/browser/account_hub.py
@@ -328,12 +328,15 @@ def _norm_follow_user(d: dict, direction: str) -> Optional[dict]:
 # 关键:关注与粉丝要点不同入口,否则两边抓到同一份(改版时改 open 候选)。
 _FOLLOW_NAV = {
     "douyin": {
+        # ⚠️ 顶栏有「关注」feed 导航(<a href="/follow?from_nav=1">,带未读角标),会和主页
+        # 统计项撞文本 —— 'text=关注' 的 .first 常点中它。dyjs: 锚定确定存在的
+        # [data-e2e="user-info-fans"],反查统计容器,只在容器内点,天然避开顶栏。
         "url": "https://www.douyin.com/user/self",
         "open": {
-            "following": ['[data-e2e="user-info-follow"]', '[data-e2e="user-following"]',
-                          'text=关注'],
-            "fan":       ['[data-e2e="user-info-fans"]', '[data-e2e="user-fans"]',
-                          'text=粉丝'],
+            "following": ['dyjs:关注', '[data-e2e="user-info-follow"]',
+                          '[data-e2e="user-following"]'],
+            "fan":       ['dyjs:粉丝', '[data-e2e="user-info-fans"]',
+                          '[data-e2e="user-fans"]'],
         },
     },
     "xhs": {
@@ -346,6 +349,34 @@ _FOLLOW_NAV = {
         "open": {"following": ['text=关注'], "fan": ['text=粉丝']},
     },
 }
+# 抖音:主页统计区里「关注」没有 data-e2e(只有编译 hash class),而「粉丝/获赞」有。
+# 所以拿 user-info-fans 当锚点:向上找到同时含「关注」「粉丝」的最小容器(= 统计区),
+# 再在容器内点目标项。顶栏的「关注」导航不在这个容器里,天然被排除。
+_DOUYIN_OPEN_STAT_JS = """(label) => {
+  const anchor = document.querySelector('[data-e2e="user-info-fans"]');
+  if (!anchor) return '';
+  // 向上找最小的、同时包含「关注」和「粉丝」的祖先 —— 那就是统计区
+  let box = anchor;
+  for (let d = 0; d < 6 && box; d++, box = box.parentElement) {
+    const t = box.textContent || '';
+    if (t.includes('关注') && t.includes('粉丝')) break;
+  }
+  if (!box) return '';
+  // 容器内找目标项:文本形如「关注22」/「22关注」
+  const re = new RegExp('^(' + label + '\\\\s*[\\\\d.万亿]*|[\\\\d.万亿]+\\\\s*' + label + ')$');
+  const hits = [...box.querySelectorAll('div,span,a')]
+    .filter(e => re.test((e.textContent || '').trim()))
+    .filter(e => { const r = e.getBoundingClientRect(); return r.width > 0 && r.height > 0; });
+  if (!hits.length) return '';
+  // 「关注」这个纯文本标签也会匹配(数字部分可为空),它只是 label,handler 在带数字的
+  // 统计项上。优先带数字的最内层;真没有数字(计数为 0 被隐藏)才退回最内层。
+  const withNum = hits.filter(e => /\\d/.test(e.textContent || ''));
+  const pool = withNum.length ? withNum : hits;
+  const el = pool[pool.length - 1];          // 最内层
+  el.click();
+  return (el.tagName + ':' + (el.textContent || '').trim()).slice(0, 40);
+}"""
+
 # 小红书:主页统计里「关注/粉丝」文案会和顶栏导航「关注」撞,用 JS 只点「紧挨数字、且不在
 # 顶栏/侧栏」的那个统计项(点它才会弹出关注/粉丝列表抽屉,进而触发列表接口)。
 _XHS_OPEN_STAT_JS = """(label) => {
@@ -565,7 +596,13 @@ async def fetch_follows(mgr: BrowserManager, identity, platform: str, uid: str,
         opened = False
         for cand in openers:
             try:
-                if cand.startswith("js:"):
+                if cand.startswith("dyjs:"):
+                    # 抖音:锚定 user-info-fans 反查统计区,只在区内点(避开顶栏「关注」导航)
+                    clicked = await page.evaluate(_DOUYIN_OPEN_STAT_JS, cand[5:])
+                    print(f"[follow] douyin stat click {cand[5:]} → {clicked!r}")
+                    if not clicked:
+                        continue
+                elif cand.startswith("js:"):
                     # 小红书:JS 精确点主页统计区的「关注/粉丝」(避开顶栏同名标签)
                     clicked = await page.evaluate(_XHS_OPEN_STAT_JS, cand[3:])
                     if not clicked:

--- a/app/browser/fetcher.py
+++ b/app/browser/fetcher.py
@@ -20,6 +20,24 @@ COMMENT_API = "aweme/v1/web/comment/list"
 _SIGN_PARAMS = ("a_bogus", "X-Bogus", "x-bogus", "msToken", "_signature", "verifyFp")
 
 
+# 作品页没拿到数据时,看页面究竟是什么状态:登录墙?空态?还是 tab 没激活?
+_WORKS_DOM_PROBE_JS = """() => {
+  const txt = (document.body.innerText || '').replace(/\\s+/g, ' ');
+  const tabs = [...document.querySelectorAll('[data-e2e*="tab"],[class*="tab"]')]
+    .map(e => (e.textContent || '').trim().slice(0, 8))
+    .filter(t => t && t.length <= 8).slice(0, 8);
+  return {
+    tabs: [...new Set(tabs)],
+    items: document.querySelectorAll('[data-e2e="user-post-list"] li, li[data-e2e]').length,
+    // 这几种文案能把「空态 / 登录墙 / 风控」区分开
+    empty: /暂无作品|还没有发布|没有更多了/.test(txt),
+    login_wall: /登录后查看|立即登录|扫码登录/.test(txt),
+    risk: /访问频繁|环境异常|验证/.test(txt),
+    body_len: txt.length,
+  };
+}"""
+
+
 async def fetch_videos(mgr: BrowserManager, identity: Identity, sec_uid: str,
                        known_ids: Set[str], max_scrolls: int = 12,
                        settle_ms: int = 1800, block_media: bool = True
@@ -28,33 +46,52 @@ async def fetch_videos(mgr: BrowserManager, identity: Identity, sec_uid: str,
     collected: Dict[str, dict] = {}
     author: Optional[dict] = None
     error = ""
+    post_hits = []        # 命中的 aweme/post 响应(判断是「没发」还是「发了解不出」)
+    api_seen = []         # 该页发出的抖音 API(post_hits 为空时,靠它看页面到底在请求什么)
 
     page = await mgr.new_page(identity, block_media)
 
     async def on_response(resp):
         nonlocal author
         url = resp.url
-        try:
-            if POST_API in url:
+        if ("douyin.com" in url and ("/aweme/v1/web/" in url or "/web/api/" in url)
+                and len(api_seen) < 40):
+            api_seen.append(f"{resp.status} {url.split('?')[0].split('douyin.com')[-1]}")
+        if POST_API in url:
+            try:
                 data = await resp.json()
-                for it in (data.get("aweme_list") or []):
-                    aid = str(it.get("aweme_id") or "")
-                    if aid:
-                        collected[aid] = it
-                        if author is None and it.get("author"):
-                            author = it["author"]
-            elif PROFILE_API in url and author is None:
+            except Exception as e:
+                # 页面跳转会丢弃 body。别静默 pass,否则「200 却没数据」永远查不出原因
+                post_hits.append(f"{resp.status} body_read_failed={e!r}")
+                return
+            lst = data.get("aweme_list")
+            post_hits.append(f"{resp.status} status_code={data.get('status_code')} "
+                             f"aweme_list={len(lst) if isinstance(lst, list) else lst!r} "
+                             f"keys={sorted(data)[:8]}")
+            for it in (lst or []):
+                aid = str(it.get("aweme_id") or "")
+                if aid:
+                    collected[aid] = it
+                    if author is None and it.get("author"):
+                        author = it["author"]
+        elif PROFILE_API in url and author is None:
+            try:
                 data = await resp.json()
-                if data.get("user"):
-                    author = data["user"]
-        except Exception:
-            pass
+            except Exception:
+                return
+            if data.get("user"):
+                author = data["user"]
 
     page.on("response", on_response)
 
     try:
         await page.goto(f"https://www.douyin.com/user/{sec_uid}",
                         wait_until="domcontentloaded", timeout=30000)
+        # 同私信/粉丝入口:没 hydrate 完,作品列表的分页请求根本不会发
+        try:
+            await page.wait_for_load_state("networkidle", timeout=15000)
+        except Exception:
+            pass
         await page.wait_for_timeout(settle_ms)
         stagnant = 0
         for _ in range(max_scrolls):
@@ -64,8 +101,10 @@ async def fetch_videos(mgr: BrowserManager, identity: Identity, sec_uid: str,
             await page.mouse.wheel(0, 4000)
             await page.wait_for_timeout(settle_ms)
             if len(collected) == before:               # 本次下滑无新增
+                # 一条都没抓到时别提前退:那是「还没开始」,不是「已经到底」。
+                # 首屏 XHR 可能比 networkidle 更晚,滚满 max_scrolls 再放弃。
                 stagnant += 1
-                if stagnant >= 2:                      # 连续两次到底,停
+                if collected and stagnant >= 2:        # 连续两次到底,停
                     break
             else:
                 stagnant = 0
@@ -74,11 +113,23 @@ async def fetch_videos(mgr: BrowserManager, identity: Identity, sec_uid: str,
     except Exception as e:
         error = f"打开主页失败: {e!r}"
     finally:
+        final_url = page.url
+        dom = {}
+        if not collected:
+            try:                        # 页面到底渲染成什么样了(tab?空态?登录墙?)
+                dom = await page.evaluate(_WORKS_DOM_PROBE_JS)
+            except Exception as e:
+                dom = {"probe_failed": repr(e)}
         try:
             await page.close()
         except Exception:
             pass
 
+    if not collected:
+        # 「aweme/post 没发出来」和「发了但 aweme_list 空/读不到」是两回事,原来一律报同一句话
+        print(f"[works] 未拿到作品; sec_uid={sec_uid[:24]}… final_url={final_url}; "
+              f"post_hits({len(post_hits)})={post_hits[:5]}; dom={dom}")
+        print(f"[works] api_seen({len(api_seen)})={api_seen[:30]}")
     new_items = [it for aid, it in collected.items() if aid not in known_ids]
     return new_items, author, error
 

--- a/app/platforms/douyin/client.py
+++ b/app/platforms/douyin/client.py
@@ -89,10 +89,16 @@ class DouyinClient:
             r = await cli.get(url, headers=self._headers(referer),
                               impersonate=self.impersonate, timeout=self.timeout)
             if r.status_code != 200 or not r.content:
+                # HTTP 200 + 空 body = 被风控拒了(接口本身可能是活的:follower/list 直连
+                # 空 body,页面里发同一个请求却正常)。静默 return None 会让上层把「被拒」
+                # 和「没有数据」混为一谈 —— 那正是 raw=0 查了半天的原因。
+                print(f"[dy-client] {path} → HTTP {r.status_code} len={len(r.content)}"
+                      f"{' (空 body:多半被风控拒,非无数据)' if r.status_code == 200 else ''}")
                 return None
             try:
                 return r.json()
             except Exception:
+                print(f"[dy-client] {path} → 非 JSON len={len(r.content)}")
                 return None
 
     # ── 用户资料(对应 NativeClient.FetchProfile)──


### PR DESCRIPTION
﻿接 #10。那个 PR 只合进了「资料刷新 + 私信同步」,后续三处修复没赶上合并,单独提上来。

同一个根因:抖音改版后前端转向异步 hydrate,而我们在 `domcontentloaded` + 固定等待之后就动手 —— 元素还没绑 handler,首屏 XHR 还没发。

## 1. 粉丝列表(`account_hub.py`)

`fetch_follows` 没等 hydrate 就去点「粉丝」,列表压根没打开。

`precise=0 broad=25` 是彻头彻尾的假象 —— `_harvest_user_lists` 从 `aweme/post`、`aweme/favorite`、`im/spotlight/relation` 里捞出 25 个无关用户对象,凑得像模像样。加 `networkidle` 后 `follower/list` 正常回包,`precise=16`,与主页「粉丝16」一致。

顺带加 `_DOUYIN_STAT_PROBE_JS`,打印关注/粉丝入口的真实标记。

## 2. `_get_json` 不再静默吞掉 HTTP 200 + 空 body(`platforms/douyin/client.py`)

`follower/list` 直连恒空 body,而**同一套签名下 `following/list` 正常、页面里发同一请求也正常** —— 是签名被风控拒(推测假 msToken,**未验证**),不是接口下线。

原来静默 `return None` 让「被拒」和「没有数据」在上层完全同形,`raw=0` 什么都说明不了。

> 我一度据此断言「`follower/list` 已废」。证据之一是伪的:浏览器 `api_seen` 里没有它,只是因为**入口压根没点开**。修好 hydrate 后 `✓/aweme/v1/web/user/follower/list/` 立刻出现。

## 3. 作品同步(`fetcher.py`)

`/user/{sec_uid}` 上 `aweme/post` 一次都没发(`post_hits=0`),而 `/user/self` 上是 200。补 `networkidle` 后恢复。

另修一个逻辑 bug:滚动循环里 `stagnant` 把「一条都没抓到」当成「已经到底」,滚两下就退出。一条都没有时那是**还没开始** —— 首屏 XHR 可能比 `networkidle` 更晚。

诊断(仅在拿不到作品时打印):`aweme/post` 的 `resp.json()` 异常不再静默 `pass`;加 `api_seen`;加 `_WORKS_DOM_PROBE_JS` 把「空态 / 登录墙 / 风控 / 有作品」四种页面状态分开 —— 原报错文案把三种猜测并列(「未登录/被风控/无公开作品」),一个都没验证。

## 4. 关注入口钉到统计区(`account_hub.py`)

主页统计区里「关注」**没有 `data-e2e`**(只有编译 hash class `kCzNsmN5`),而顶栏有个「关注」feed 导航(`<a href=/follow?from_nav=1>`,带未读角标),两者文本相同。原候选里的 `text=关注` 用 `.first` 常点中顶栏,且会坏成「抓到 25 个无关用户」的样子而**不报错**。

改为锚定确定存在的 `[data-e2e=user-info-fans]`,向上找同时含「关注」「粉丝」的最小容器(= 统计区),只在容器内点。顶栏不在容器里,天然排除,不依赖任何未知标记。

注意:统计区里「关注」这个纯文本 label 也匹配(正则数字部分可为空),但 handler 在带数字的统计项上 —— 优先选带数字的最内层。

## 验证

六个离线 fixture(`playwright` + 手工编码 protobuf)全绿:

- **关注入口**:点中统计区「关注22」/「粉丝16」、顶栏**零点击**、无锚点(未 hydrate)时安全返回空而不乱点
- **作品页状态**:「空态 / 登录墙 / 风控 / 有作品」四态互不混淆
- **统计项探针**:两种排版(`关注 22` / `1234 粉丝`)命中,隐藏元素与正文排除
- 另含 #10 的三个:protobuf 层级、async handler 竞态、popup 捕获

实测:粉丝 16、作品与资料均恢复。

另有一层既有保险:点完要等 `following/list` 或 `follower/list` 回包才算 `opened`。就算 `dyjs` 哪天点歪,也不会把粉丝当关注写进库,而是换下一个候选。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
