### PR TITLE
feat: add OrcaRouter as a named AI provider preset

### DIFF
--- a/app/web/app.js
+++ b/app/web/app.js
@@ -3575,9 +3575,30 @@ async function loadSettings() {
       $("ai-temp").value = s.ai_temperature || "0.9";
       $("ai-prompt").value = s.ai_prompt || "";
       $("ai-key").placeholder = s.ai_api_key_set ? "已保存(留空=不修改)" : "API Key";
+      if ($("ai-provider")) {
+        // Keep the preset selector in sync when the saved base URL matches one.
+        $("ai-provider").value = Object.keys(AI_PROVIDERS).find(k =>
+          AI_PROVIDERS[k].base_url === ($("ai-base").value.trim() || "")) || "";
+      }
     }
     csSyncAll();
   } catch (e) {}
+}
+// ─── AI 文案生成设置 ───
+// Named provider presets for the OpenAI-compatible comment-copy generator.
+// Selecting one fills Base URL / model so the gateway is a first-class provider
+// instead of an anonymous custom base URL. Custom services remain supported.
+const AI_PROVIDERS = {
+  orcarouter: { name: "OrcaRouter", base_url: "https://api.orcarouter.ai/v1", model: "orcarouter/auto" },
+};
+
+function applyAiProvider() {
+  const p = AI_PROVIDERS[$("ai-provider").value];
+  if (!p) return;
+  $("ai-base").value = p.base_url;
+  $("ai-model").value = p.model;
+  validateAiField($("ai-base"), false);
+  validateAiField($("ai-model"), false);
 }
 async function saveAiSettings() {
   if (!validateAiSettings(false)) return;

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -2512,6 +2512,14 @@
         <input type="checkbox" id="ai-enabled">
         <span class="switch-copy"><b>启用大模型生成文案</b><span>关闭后只使用规则中的本地模板库</span></span>
       </label>
+      <div class="form-field">
+        <label for="ai-provider">服务商预设</label>
+        <select id="ai-provider" onchange="applyAiProvider()" aria-label="AI 服务商预设">
+          <option value="">自定义服务（手动填写 Base URL / 模型）</option>
+          <option value="orcarouter">OrcaRouter（AI 网关 · 自适应路由）</option>
+        </select>
+        <div class="field-help">选择预设自动填充接口地址与模型名称，也支持手动填写任意 OpenAI 兼容服务</div>
+      </div>
       <div class="form-grid">
         <div class="form-field">
           <label for="ai-base">接口地址</label>
@@ -2542,7 +2550,7 @@
       </div>
       <div class="form-note">
         <svg aria-hidden="true"><use href="#i-info"/></svg>
-        <span>兼容 OpenAI <code>/chat/completions</code> 的服务。调用失败时会自动回退到当前规则的模板库。</span>
+        <span>兼容 OpenAI <code>/chat/completions</code> 的服务，已内置 <a href="https://www.orcarouter.ai" target="_blank" rel="noopener noreferrer">OrcaRouter</a> 网关预设（自适应路由与故障切换）。调用失败时会自动回退到当前规则的模板库。</span>
       </div>
       <div class="form-actions">
         <span class="status-text" id="ai-msg" role="status" aria-live="polite"></span>


### PR DESCRIPTION
Users of CreatorHub's built-in LLM comment generation can now pick **OrcaRouter** as a named provider in Settings → 大模型 API. Choosing it fills the Base URL (`https://api.orcarouter.ai/v1`) and model (`orcarouter/auto`) in one click, so the gateway stops being an anonymous custom base URL and becomes a first-class provider in the existing OpenAI-compatible `/chat/completions` flow.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means CreatorHub users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. The preset mirrors the existing DeepSeek-style custom-config path in `app/engine/compose.py` — same `chat/completions` call, same fallback to the local template library when the request fails. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Concretely, `app/web/index.html` gains a "服务商预设" (provider preset) selector above the Base URL / model fields, and `app/web/app.js` adds an `AI_PROVIDERS` preset map with `applyAiProvider()`; `loadSettings()` keeps the selector in sync when a saved base URL matches a preset. Verified against the full test suite (481 passed; the 3 failures are pre-existing on a clean checkout — a Python `TimeoutError` identity quirk in `test_risk_api_gates` and `libglib`-less headless container in `test_xhs_login_flow`), and live-tested the preset's exact request shape against `https://api.orcarouter.ai/v1/chat/completions` with `orcarouter/auto` — HTTP 200 and a generated comment in the same `choices[0].message.content` shape `compose.generate()` already parses.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
