### PR TITLE
feat(notifier): add channel config validation and per-channel results

### DIFF
--- a/.ai-workflow/01-plan.md
+++ b/.ai-workflow/01-plan.md
@@ -1,0 +1,168 @@
+# 01-plan · 通知渠道健壮性增强（notifier 小功能）
+
+## 1. 背景与目标
+
+`app/notifier/__init__.py` 是唯一负责 Bark / 钉钉 / Telegram 三渠道推送的模块，但它存在三个明显缺口：
+
+1. **配置缺少前置校验**：`app/main.py` 的 `add_channel` 只校验 `type` 是否在 `CHANNEL_TYPES` 内（`app/main.py:6810`），`config` 里的 `key` / `webhook` / `bot_token` / `chat_id` 等必填字段完全不做校验，错误只能等到「发送/测试」时才以 `(False, "缺少 xxx")` 的运行时字符串暴露，且前端无法区分「配置错误」与「发送失败」。
+2. **钉钉加签不可单测**：`_send_dingtalk` 把 `hmac` + `base64` + `quote_plus` 全部内联在异步函数里（`app/notifier/__init__.py:40-44`），`time.time()` 直接写在函数中，签名逻辑无法确定性单测。
+3. **批量发送结果被吞掉**：`notify_all` 逐个 `await send_one(...)` 后丢弃返回值（`app/notifier/__init__.py:82-85`），调用方（`app/engine/monitor.py` 多处）无法感知部分渠道失败。
+
+目标：在不触碰抓取、发布、登录、风控任何核心流程的前提下，为该模块补齐**可 pytest 验证的纯函数能力**——配置校验、钉钉加签、逐渠道结果汇总。三者均为纯增量、向后兼容，1–2 小时可完成。
+
+## 2. 验收标准
+
+以下全部由新增的 `tests/test_notifier.py` 覆盖，`pytest tests/test_notifier.py` 应全绿，且不产生任何网络请求：
+
+1. `validate_channel_config(ch_type, config)` 对合法配置返回 `[]`：
+   - bark：含非空 `key`；
+   - dingtalk：含 `http(s)://` 的 `webhook`；
+   - telegram：同时含非空 `bot_token` 与 `chat_id`。
+2. 对非法配置返回非空问题列表，且信息可读：
+   - bark 缺 `key`；
+   - dingtalk 缺 `webhook` 或 `webhook` 不是 http(s)；
+   - telegram 缺 `bot_token` / `chat_id`，或 `api_base` 存在但不是 http(s)；
+   - 未知渠道类型返回 `["未知渠道类型: xxx"]`。
+3. `_dingtalk_sign(secret, timestamp_ms)` 输出与「`hmac.new(secret, f"{ts}\n{secret}", sha256)` → `base64` → `quote_plus`」独立重算结果逐字节一致；且结果不含裸 `+`、`/`、`=`（URL 安全）。
+4. `_send_dingtalk` 继续使用 `_dingtalk_sign`，签名行为与改动前完全一致（用固定 `timestamp_ms` 的 mock 验证拼出的 webhook 尾部参数）。
+5. `notify_all(channels, title, text)` 返回 `list[dict]`，每个元素为 `{"type", "ok", "detail"}`，与 `send_one` 返回值一一对应；单个渠道失败/抛异常不中断其它渠道（保持现有语义）。
+6. 不新增第三方依赖，不修改 `send_one` 的对外签名与返回值结构（仍为 `(bool, str)`）。
+
+## 3. 涉及文件
+
+- **修改**：`app/notifier/__init__.py`
+  - 新增纯函数：`_is_http_url`、`validate_channel_config`、`_dingtalk_sign`。
+  - `_send_dingtalk` 内部改用 `_dingtalk_sign`（行为不变）。
+  - `notify_all` 改为返回逐渠道结果列表。
+- **新增**：`tests/test_notifier.py`
+  - pytest 风格测试（异步场景用 `asyncio.run`，不引入 pytest-asyncio）。
+- **只读参考（不改）**：
+  - `app/main.py:6808-6853`（通知渠道 CRUD 与测试接口，用于确认当前校验缺口与接口约定）。
+  - `tests/test_reporting.py`、`tests/test_web_status_labels.py`（现有测试风格与 `pytest.ini` 约定）。
+
+## 4. 分步实现方案
+
+### 第 1 步：新增 URL 校验纯函数
+
+在 `app/notifier/__init__.py` 顶部（`TIMEOUT` 之后）新增：
+
+```python
+def _is_http_url(value: str) -> bool:
+    parts = urllib.parse.urlsplit(value)
+    return parts.scheme in ("http", "https") and bool(parts.netloc)
+```
+
+说明：只判断协议与 host，不做网络访问。
+
+### 第 2 步：新增配置校验函数
+
+```python
+def validate_channel_config(ch_type: str, config: dict | None) -> list[str]:
+    """返回渠道配置的问题列表；空列表表示可用。纯函数，不触发网络。"""
+    cfg = config or {}
+    if ch_type not in CHANNEL_TYPES:
+        return [f"未知渠道类型: {ch_type}"]
+
+    errors: list[str] = []
+    if ch_type == "bark":
+        if not (cfg.get("key") or "").strip():
+            errors.append("缺少 bark key")
+        server = (cfg.get("server") or "").strip()
+        if server and not _is_http_url(server):
+            errors.append("bark server 必须是 http(s) 地址")
+    elif ch_type == "dingtalk":
+        webhook = (cfg.get("webhook") or "").strip()
+        if not webhook:
+            errors.append("缺少 webhook")
+        elif not _is_http_url(webhook):
+            errors.append("webhook 必须是 http(s) 地址")
+    elif ch_type == "telegram":
+        if not (cfg.get("bot_token") or "").strip():
+            errors.append("缺少 bot_token")
+        if not (cfg.get("chat_id") or "").strip():
+            errors.append("缺少 chat_id")
+        api = (cfg.get("api_base") or "").strip()
+        if api and not _is_http_url(api):
+            errors.append("api_base 必须是 http(s) 地址")
+    return errors
+```
+
+### 第 3 步：抽取钉钉加签纯函数并替换内联实现
+
+```python
+def _dingtalk_sign(secret: str, timestamp_ms: str) -> str:
+    """按钉钉加签规范返回 URL 编码后的 sign。"""
+    message = f"{timestamp_ms}\n{secret}".encode("utf-8")
+    digest = hmac.new(secret.encode("utf-8"), message, hashlib.sha256).digest()
+    return urllib.parse.quote_plus(base64.b64encode(digest))
+```
+
+`_send_dingtalk` 中删除原来的三行内联（`ts` / `sign` / `webhook +=`），替换为：
+
+```python
+    ts = str(round(time.time() * 1000))
+    webhook += f"&timestamp={ts}&sign={_dingtalk_sign(secret, ts)}"
+```
+
+注意：`quote_plus(bytes)` 与旧实现 `quote_plus(base64.b64encode(...))` 完全等价，保持既有签名结果不变。
+
+### 第 4 步：`notify_all` 返回逐渠道结果
+
+```python
+async def notify_all(channels: list[dict], title: str, text: str) -> list[dict]:
+    """channels: [{type, config(dict)} ...]。逐个发送，失败不影响其它。"""
+    results: list[dict] = []
+    for ch in channels:
+        ch_type = ch.get("type")
+        try:
+            ok, detail = await send_one(ch_type, ch.get("config") or {}, title, text)
+        except Exception as e:
+            ok, detail = False, repr(e)
+        results.append({"type": ch_type, "ok": ok, "detail": detail})
+    return results
+```
+
+调用方 `monitor.py` 现有 `await notify_all(...)` 忽略返回值，不受影响；后续如需 UI 展示部分失败，可直接消费返回值（本次不接入）。
+
+### 第 5 步：编写测试
+
+新增 `tests/test_notifier.py`，见第 5 节测试计划。
+
+## 5. 测试计划
+
+文件 `tests/test_notifier.py`，全部为同步 pytest 函数；涉及异步的用 `asyncio.run(...)` 包装（仓库现有测试即此风格，见 `tests/test_editable_configs.py`）。
+
+| 用例 | 验证点 |
+|---|---|
+| `test_validate_bark_valid_and_missing_key` | 合法 bark 返回 `[]`；缺 key 返回含「缺少 bark key」 |
+| `test_validate_dingtalk_requires_http_webhook` | 合法 webhook 通过；缺 webhook / `ftp://...` / `javascript:...` 失败 |
+| `test_validate_telegram_requires_token_chat_id_and_api_base` | 缺 token、缺 chat_id、非法 api_base 分别命中对应错误 |
+| `test_validate_unknown_channel` | 未知类型返回 `["未知渠道类型: xxx"]` |
+| `test_validate_config_accepts_none` | `config=None` 与 `{}` 行为一致，不抛异常 |
+| `test_dingtalk_sign_matches_hmac_sha256` | 用 `hmac`/`base64`/`quote_plus` 独立重算，断言与 `_dingtalk_sign` 相等 |
+| `test_dingtalk_sign_is_url_safe` | 结果不含裸 `+`、`/`、`=`，且可被 `unquote_plus` 还原为 base64 |
+| `test_notify_all_returns_per_channel_results` | `unittest.mock.patch` 替换 `app.notifier.send_one` 为受控异步假函数，断言返回列表长度与逐项 `{type, ok, detail}` |
+| `test_notify_all_continues_when_one_channel_fails` | 假函数对其中一个抛异常，断言仍返回全部结果且不中断 |
+| `test_send_one_unknown_channel_no_network` | `send_one("unknown", ...)` 返回 `(False, ...)`，不触发网络 |
+| `test_send_one_swallows_sender_exception` | 临时替换 `_SENDERS["telegram"]` 为抛异常的异步函数，断言 `send_one` 捕获并返回 `(False, repr(...))` |
+
+（必选）`test_dingtalk_webhook_url_contains_timestamp_and_sign`：mock `httpx.AsyncClient` 捕获 POST URL，断言尾部含 `&timestamp=` 与 `&sign=`，且 sign 等于 `_dingtalk_sign` 的结果。
+
+## 6. 风险与回滚点
+
+- **签名行为漂移风险**：`_dingtalk_sign` 抽取后若与旧实现有细微差异，会影响钉钉推送。缓解：测试用 `test_dingtalk_sign_matches_hmac_sha256` 与必选 URL 集成断言把行为钉死；回滚点 = 将 `_send_dingtalk` 恢复为原三行内联。
+- **`notify_all` 返回值变更**：属纯增量（旧代码忽略返回值），无调用方破坏；回滚点 = 恢复为不返回。
+- **`validate_channel_config` 未接入 API**：本次只提供纯函数，不改 `main.py`，故不会改变线上行为；若后续接入需单独评审。
+- **依赖/环境风险**：不新增依赖，测试仅用标准库 `hmac`/`base64`/`urllib`/`unittest.mock`，避免新环境问题。
+
+## 7. 明确禁止改动范围
+
+- **核心流程一律不碰**：`app/platforms/**`、`app/browser/**`、`app/engine/monitor.py`、`app/engine/collection.py`、`app/engine/downloader.py`、`app/engine/share_downloader.py`、`app/engine/compose.py`、`app/engine/im_receiver.py`、`app/risk.py`、`app/risk_admin.py`、`app/netfp.py`、`app/windowing.py`。
+- **API/前端不碰**：`app/main.py`（含通知渠道 CRUD 与测试接口）、`app/web/app.js`、`app/web/index.html` 本次不做任何改动；`validate_channel_config` 是否接入 API 留待后续。
+- **配置与工程文件不碰**：`config.example.yaml`、`config.yaml`、`requirements.txt`、`package.json`、`pytest.ini`、`start.cmd` / `start.sh`、`README.md`。
+- **不新增依赖、不迁移数据库、不改模型**：`app/models.py`、`app/db.py` 保持原样。
+- 允许改动的仅两处：`app/notifier/__init__.py` 与新增 `tests/test_notifier.py`。
+
+---
+
+**结论**：我选择给 `app/notifier/__init__.py` 增加「配置校验 + 钉钉加签纯函数 + `notify_all` 逐渠道结果」三项小改进。理由是它完全落在通知辅助层，不触碰抓取/发布/登录/风控任何核心流程，且目前该模块零测试、`notify_all` 结果被静默丢弃是真实缺口。三项改动都是纯增量、可回滚，用标准库即可完成确定性 pytest 验证，约 1–2 小时即可交付。

--- a/.ai-workflow/02-implement.md
+++ b/.ai-workflow/02-implement.md
@@ -1,0 +1,18 @@
+# 02-implement · 实现记录
+
+- 分支：`feat/demo-dual-agent`
+- 变更文件：
+  - `app/notifier/__init__.py`（修改）
+  - `tests/test_notifier.py`（新增）
+- 实现要点：
+  - 新增 `validate_channel_config`：纯函数校验 bark / dingtalk / telegram 配置，未知渠道返回可读错误。
+  - 新增 `_dingtalk_sign`：把钉钉 hmac 加签抽成可确定复现的纯函数，`_send_dingtalk` 行为保持兼容。
+  - `notify_all` 改为逐渠道收集 `{type, ok, detail}` 并返回；单渠道异常由调用处捕获，不影响其它渠道。
+- 测试：
+  - 临时虚拟环境安装 httpx + pytest 后运行 `pytest tests/test_notifier.py -q`
+  - 首轮：`11 passed in 0.20s`
+  - 按复审意见修复后增加钉钉集成与样例数据集用例：`14 passed in 0.16s`
+- 复审：
+  - 第一轮 Claude Code：整体通过，2 条中危建议已修复
+  - 第二轮 Claude Code：通过（可合并），仅剩 2 条文档/工作区提示项已处理
+- 未改动：核心抓取/发布/登录/风控、API、前端、依赖与配置文件（按 01-plan 第 7 节执行）。

--- a/.ai-workflow/03-review.md
+++ b/.ai-workflow/03-review.md
@@ -1,0 +1,64 @@
+# 03-review · 代码复审（第二轮 · 只读）
+
+复审对象：`app/notifier/__init__.py`（修改）、`tests/test_notifier.py`（新增），对照 `.ai-workflow/01-plan.md` 与第一轮 03-review 的 M1/M2/低危项。
+复审方式：仅静态阅读，未运行任何命令、未修改任何代码。
+
+## 整体结论
+
+**通过**（可合并）。第一轮 M1、M2 及低危项 L1–L4 均已按意见修复并同步方案；仅剩两处非阻塞残留（见下「仍存在的问题」）。
+
+---
+
+## 第一轮问题逐项复核
+
+### M1. 钉钉时间戳 `round` vs `int` 漂移 —— 通过
+- 实现保持 `round`：`app/notifier/__init__.py:83` 仍为 `ts = str(round(time.time() * 1000))`。
+- 方案已同步为 `round`：`01-plan.md:103` 为 `ts = str(round(time.time() * 1000))`，与实现一致。
+- 方案第 3 步不再要求 `int`，实现/方案/测试三处语义一致（测试用 `fixed_ms / 1000` 打补丁后 `round` 回整数，见 `tests/test_notifier.py:110`）。通过。
+
+### M2. mock httpx 的 `_send_dingtalk` 集成测试 —— 通过
+- `tests/test_notifier.py:81-119` 新增 `test_dingtalk_webhook_url_contains_timestamp_and_sign`：
+  - 用 `patch("app.notifier.time.time", return_value=fixed_ms / 1000)` 固定时间戳；
+  - 用 `patch("app.notifier.httpx.AsyncClient", FakeClient)` mock 客户端，捕获 POST URL；
+  - 断言 `&timestamp={fixed_ms}` 在 URL 中，且 `&sign=` 等于 `_dingtalk_sign(secret, str(fixed_ms))` 的独立重算结果。
+- 满足验收标准 4 与方案第 5 节「必选」项。通过。
+
+### L1. `test_dingtalk_sign_is_url_safe` 断言偏弱 —— 通过
+- `tests/test_notifier.py:70-78` 已强化：除不含裸 `+`/`/`/`=` 外，新增 `base64.b64decode(unquote_plus(sign))` 并与独立 `hmac` digest 逐字节比较。通过。
+
+### L2. `validate_channel_config` 分支覆盖缺口 —— 通过
+- 新增 `test_validate_bark_invalid_server`（`tests/test_notifier.py:29-33`），覆盖 bark 非法 `server`；
+- `test_validate_dingtalk_requires_http_webhook` 增加 `http://` 合法 webhook 断言（`tests/test_notifier.py:20-22`）；
+- `test_validate_telegram_requires_token_chat_id_and_api_base` 增加合法 `api_base` 通过路径（`tests/test_notifier.py:39-41`）。
+- 三个缺口均已补齐。通过。
+
+### L3. `notify_all` 实现与方案第 4 步不一致 —— 通过
+- 方案第 4 步已更新为带 `try/except` 的实现（`01-plan.md:111-123`），与 `app/notifier/__init__.py:122-132` 一致。通过。
+
+### L4. `_dingtalk_sign` 类型标注与方案不一致 —— 通过
+- 方案第 3 步已统一为 `timestamp_ms: str`（`01-plan.md:93`），与实现 `app/notifier/__init__.py:58` 及测试传参一致。通过。
+
+---
+
+## 仍存在的问题（均不阻塞合并）
+
+### R1. 方案第 6 节仍将 URL 集成断言标为「可选」，与第 5 节「必选」矛盾
+- 文件：`01-plan.md:153`
+- 现状：第 5 节表格（`01-plan.md:149`）已把 `test_dingtalk_webhook_url_contains_timestamp_and_sign` 标为「必选」，但第 6 节风险缓解仍写「与（可选）URL 集成断言把行为钉死」。
+- 影响：纯文档措辞不一致，无代码影响；M2 本身已实现并通过。
+- 建议：将 `01-plan.md:153` 的「（可选）」改为「必选」，或删去括注，消除遗留矛盾。
+
+### R2. 工作区仍有未跟踪的 `debug.log`
+- 文件：工作区根目录 `debug.log`（untracked，本次仍存在）
+- 影响：非代码改动，不破坏逻辑；若被误提交会污染仓库。
+- 建议：确认其为本地调试产物，加入 `.gitignore` 或在合并前清理（本复审未做任何改动）。
+
+---
+
+## 逐项检查结论（第二轮）
+
+1. **是否越界改动方案禁止的文件**：通过。仍仅 `app/notifier/__init__.py`（修改）与 `tests/test_notifier.py`（新增）；核心流程、API/前端、配置与工程文件未改动。（另见 R2 的 `debug.log` 提示。）
+2. **钉钉签名抽取后是否与原逻辑一致**：通过。算法一致，且时间戳已统一为 `round`，实现/方案/测试一致（M1）。
+3. **`validate_channel_config` 边界与返回信息**：通过。bark/dingtalk/telegram 的必填与可选 http(s) 校验、`config=None` 等价均已覆盖（L1/L2）。
+4. **`notify_all` 返回逐渠道结果是否破坏现有调用方语义**：通过。实现与方案第 4 步一致（L3），调用方忽略返回值不受影响。
+5. **测试是否有遗漏或脆弱断言**：通过。已补 mock httpx 的集成测试（M2），并强化 URL 安全断言（L1）。剩余仅 R1 方案措辞与 R2 工作区文件两项非阻塞残留。

--- a/app/notifier/__init__.py
+++ b/app/notifier/__init__.py
@@ -20,6 +20,48 @@ import httpx
 TIMEOUT = 12.0
 
 
+def _is_http_url(value: str) -> bool:
+    parts = urllib.parse.urlsplit(value)
+    return parts.scheme in ("http", "https") and bool(parts.netloc)
+
+
+def validate_channel_config(ch_type: str, config: dict | None) -> List[str]:
+    """返回渠道配置的问题列表；空列表表示可用。纯函数，不触发网络。"""
+    cfg = config or {}
+    if ch_type not in CHANNEL_TYPES:
+        return [f"未知渠道类型: {ch_type}"]
+
+    errors: List[str] = []
+    if ch_type == "bark":
+        if not (cfg.get("key") or "").strip():
+            errors.append("缺少 bark key")
+        server = (cfg.get("server") or "").strip()
+        if server and not _is_http_url(server):
+            errors.append("bark server 必须是 http(s) 地址")
+    elif ch_type == "dingtalk":
+        webhook = (cfg.get("webhook") or "").strip()
+        if not webhook:
+            errors.append("缺少 webhook")
+        elif not _is_http_url(webhook):
+            errors.append("webhook 必须是 http(s) 地址")
+    elif ch_type == "telegram":
+        if not (cfg.get("bot_token") or "").strip():
+            errors.append("缺少 bot_token")
+        if not (cfg.get("chat_id") or "").strip():
+            errors.append("缺少 chat_id")
+        api_base = (cfg.get("api_base") or "").strip()
+        if api_base and not _is_http_url(api_base):
+            errors.append("api_base 必须是 http(s) 地址")
+    return errors
+
+
+def _dingtalk_sign(secret: str, timestamp_ms: str) -> str:
+    """按钉钉机器人加签规则生成 URL 安全签名，结果可由同一输入复现。"""
+    raw = base64.b64encode(hmac.new(
+        secret.encode(), f"{timestamp_ms}\n{secret}".encode(), hashlib.sha256).digest())
+    return urllib.parse.quote_plus(raw)
+
+
 async def _send_bark(cfg: dict, title: str, text: str) -> Tuple[bool, str]:
     key = (cfg.get("key") or "").strip()
     if not key:
@@ -39,9 +81,7 @@ async def _send_dingtalk(cfg: dict, title: str, text: str) -> Tuple[bool, str]:
     keyword = (cfg.get("keyword") or "").strip()
     if secret:
         ts = str(round(time.time() * 1000))
-        sign = base64.b64encode(hmac.new(
-            secret.encode(), f"{ts}\n{secret}".encode(), hashlib.sha256).digest())
-        webhook += f"&timestamp={ts}&sign={urllib.parse.quote_plus(sign)}"
+        webhook += f"&timestamp={ts}&sign={_dingtalk_sign(secret, ts)}"
     content = f"{keyword} {title}\n{text}".strip()
     async with httpx.AsyncClient(timeout=TIMEOUT) as c:
         r = await c.post(webhook, json={"msgtype": "text", "text": {"content": content}})
@@ -79,7 +119,14 @@ async def send_one(ch_type: str, config: dict, title: str, text: str) -> Tuple[b
         return False, repr(e)
 
 
-async def notify_all(channels: List[dict], title: str, text: str):
-    """channels: [{type, config(dict)} ...]。逐个发送,失败不影响其它。"""
+async def notify_all(channels: List[dict], title: str, text: str) -> List[dict]:
+    """channels: [{type, config(dict)} ...]。逐个发送，单渠道失败不影响其它。"""
+    results: List[dict] = []
     for ch in channels:
-        await send_one(ch["type"], ch.get("config") or {}, title, text)
+        ch_type = ch.get("type")
+        try:
+            ok, detail = await send_one(ch_type, ch.get("config") or {}, title, text)
+        except Exception as e:
+            ok, detail = False, repr(e)
+        results.append({"type": ch_type, "ok": ok, "detail": detail})
+    return results

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,0 +1,191 @@
+import asyncio
+import base64
+import hashlib
+import hmac
+import urllib.parse
+from unittest.mock import patch
+
+import app.notifier as notifier
+
+
+def test_validate_bark_valid_and_missing_key():
+    assert notifier.validate_channel_config("bark", {"key": "abc"}) == []
+    errors = notifier.validate_channel_config("bark", {})
+    assert errors == ["缺少 bark key"]
+
+
+def test_validate_dingtalk_requires_http_webhook():
+    ok = {"webhook": "https://oapi.dingtalk.com/robot/send?access_token=x"}
+    assert notifier.validate_channel_config("dingtalk", ok) == []
+    assert notifier.validate_channel_config(
+        "dingtalk", {"webhook": "http://example.com/robot"}
+    ) == []
+    assert notifier.validate_channel_config("dingtalk", {}) == ["缺少 webhook"]
+    for bad in ("ftp://example.com/x", "javascript:alert(1)"):
+        errors = notifier.validate_channel_config("dingtalk", {"webhook": bad})
+        assert errors == ["webhook 必须是 http(s) 地址"]
+
+
+def test_validate_bark_invalid_server():
+    cfg = {"key": "k", "server": "ftp://bad"}
+    assert notifier.validate_channel_config("bark", cfg) == [
+        "bark server 必须是 http(s) 地址"
+    ]
+
+
+def test_validate_telegram_requires_token_chat_id_and_api_base():
+    ok = {"bot_token": "t", "chat_id": "c"}
+    assert notifier.validate_channel_config("telegram", ok) == []
+    assert notifier.validate_channel_config(
+        "telegram", {"bot_token": "t", "chat_id": "c", "api_base": "https://api.telegram.org"}
+    ) == []
+    errors = notifier.validate_channel_config("telegram", {})
+    assert "缺少 bot_token" in errors
+    assert "缺少 chat_id" in errors
+    bad = {"bot_token": "t", "chat_id": "c", "api_base": "ftp://bad"}
+    assert notifier.validate_channel_config("telegram", bad) == [
+        "api_base 必须是 http(s) 地址"
+    ]
+
+
+def test_validate_unknown_channel():
+    assert notifier.validate_channel_config("wechat", {}) == ["未知渠道类型: wechat"]
+
+
+def test_validate_config_accepts_none():
+    assert notifier.validate_channel_config("bark", None) == notifier.validate_channel_config(
+        "bark", {}
+    )
+    assert notifier.validate_channel_config("dingtalk", None) == ["缺少 webhook"]
+
+
+def test_validate_channel_sample_dataset():
+    cases = [
+        ("bark", {"key": "device-key-001"}, []),
+        ("bark", {"key": "", "server": "https://api.day.app"}, ["缺少 bark key"]),
+        ("bark", {"key": "device-key-001", "server": "ftp://bad"}, ["bark server 必须是 http(s) 地址"]),
+        ("dingtalk", {"webhook": "https://oapi.dingtalk.com/robot/send?access_token=sample"}, []),
+        ("dingtalk", {"webhook": "ftp://oapi.dingtalk.com/x"}, ["webhook 必须是 http(s) 地址"]),
+        ("telegram", {"bot_token": "123:bot", "chat_id": "chat-1"}, []),
+        ("telegram", {"bot_token": "123:bot", "chat_id": ""}, ["缺少 chat_id"]),
+        ("telegram", {"bot_token": "", "chat_id": "chat-1"}, ["缺少 bot_token"]),
+        ("unknown", {"whatever": 1}, ["未知渠道类型: unknown"]),
+    ]
+    for ch_type, config, expected in cases:
+        assert notifier.validate_channel_config(ch_type, config) == expected, ch_type
+
+
+def test_dingtalk_sign_matches_hmac_sha256():
+    secret = "SEC123"
+    ts = "1720000000000"
+    expected = urllib.parse.quote_plus(base64.b64encode(hmac.new(
+        secret.encode(), f"{ts}\n{secret}".encode(), hashlib.sha256).digest()))
+    assert notifier._dingtalk_sign(secret, ts) == expected
+
+
+def test_dingtalk_sign_is_url_safe():
+    sign = notifier._dingtalk_sign("SECabc", "1720000000000")
+    assert "+" not in sign
+    assert "/" not in sign
+    assert "=" not in sign
+    decoded = base64.b64decode(urllib.parse.unquote_plus(sign))
+    expected = hmac.new(
+        b"SECabc", b"1720000000000\nSECabc", hashlib.sha256).digest()
+    assert decoded == expected
+
+
+def test_dingtalk_webhook_url_contains_timestamp_and_sign():
+    secret = "SEC123"
+    fixed_ms = 1720000000000
+    cfg = {
+        "webhook": "https://oapi.dingtalk.com/robot/send?access_token=x",
+        "secret": secret,
+    }
+    captured = {}
+
+    class FakeResponse:
+        text = "ok"
+
+        def json(self):
+            return {"errcode": 0}
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def post(self, url, **kwargs):
+            captured["url"] = url
+            return FakeResponse()
+
+    with patch("app.notifier.time.time", return_value=fixed_ms / 1000), patch(
+        "app.notifier.httpx.AsyncClient", FakeClient
+    ):
+        ok, detail = asyncio.run(
+            notifier._send_dingtalk(cfg, "title", "body")
+        )
+
+    assert ok
+    assert f"&timestamp={fixed_ms}" in captured["url"]
+    assert f"&sign={notifier._dingtalk_sign(secret, str(fixed_ms))}" in captured["url"]
+
+
+def test_notify_all_returns_per_channel_results():
+    async def fake_send(ch_type, config, title, text):
+        if ch_type == "bark":
+            return True, "ok"
+        return False, "missing"
+
+    channels = [
+        {"type": "bark", "config": {"key": "k"}},
+        {"type": "telegram", "config": {}},
+    ]
+    with patch.object(notifier, "send_one", side_effect=fake_send):
+        results = asyncio.run(notifier.notify_all(channels, "title", "body"))
+    assert results == [
+        {"type": "bark", "ok": True, "detail": "ok"},
+        {"type": "telegram", "ok": False, "detail": "missing"},
+    ]
+
+
+def test_notify_all_continues_when_one_channel_fails():
+    calls = 0
+
+    async def fake_send(ch_type, config, title, text):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("boom")
+        return True, "ok"
+
+    channels = [
+        {"type": "bark", "config": {}},
+        {"type": "telegram", "config": {}},
+    ]
+    with patch.object(notifier, "send_one", side_effect=fake_send):
+        results = asyncio.run(notifier.notify_all(channels, "title", "body"))
+    assert len(results) == 2
+    assert results[0]["ok"] is False
+    assert "boom" in results[0]["detail"]
+    assert results[1] == {"type": "telegram", "ok": True, "detail": "ok"}
+
+
+def test_send_one_unknown_channel_no_network():
+    ok, detail = asyncio.run(notifier.send_one("unknown", {}, "title", "body"))
+    assert ok is False
+    assert "未知渠道类型" in detail
+
+
+def test_send_one_swallows_sender_exception():
+    async def boom(cfg, title, text):
+        raise ValueError("bad sender")
+
+    with patch.dict(notifier._SENDERS, {"telegram": boom}):
+        ok, detail = asyncio.run(notifier.send_one("telegram", {}, "title", "body"))
+    assert ok is False
+    assert "bad sender" in detail


### PR DESCRIPTION
双 AI Agent 串行工作流演练（Claude Code 规划/复审，Codex 实现/测试），feature 分支从 fork 提交 PR。

变更内容：
- `app/notifier/__init__.py`：新增 `validate_channel_config` 配置校验、钉钉签名辅助函数，`notify_all` 改为逐渠道返回 `{type, ok, detail}` 并捕获单渠道异常。
- `tests/test_notifier.py`：覆盖合法/非法配置、签名、逐渠道结果与样例数据集。
- `.ai-workflow/01-plan.md`、`02-implement.md`、`03-review.md`：记录方案、实现与两轮 Code Review 结论。

验证：
- `pytest tests/test_notifier.py` → 14 passed
- 临时虚拟环境：httpx 0.28.1 / pytest 9.1.1
- 人工检查：`git diff --check` 通过，无真实密钥进入提交